### PR TITLE
Completing SB3 logger metrics to match Visdom & dump SB3 logger in JSON

### DIFF
--- a/alg/logger.py
+++ b/alg/logger.py
@@ -745,3 +745,33 @@ def read_csv(filename: str) -> pandas.DataFrame:
     :return: the data in the csv
     """
     return pandas.read_csv(filename, index_col=None, comment="#")
+
+
+# ================================================================
+# Metrics
+# ================================================================
+
+
+def monotony(serie: np.ndarray) -> float:
+    """Compute the monotony of a serie.
+
+    It is the mean of the sign of the difference between two consecutive values.
+    """
+    if len(serie) < 2:
+        return 0.0
+
+    diff = serie[:-1] - serie[1:]
+    signs = np.sign(diff)
+    return np.mean(signs[signs != 0])
+
+
+def stability(serie: np.ndarray) -> float:
+    """Compute the stability of a serie.
+
+    It is the mean of the absolute value of the difference between two consecutive values.
+    """
+    if len(serie) < 2:
+        return 0.0
+
+    diff = serie[:-1] - serie[1:]
+    return np.mean(np.abs(diff))

--- a/args.py
+++ b/args.py
@@ -225,7 +225,7 @@ parser.add_argument(
     "--graph_pooling",
     type=str,
     default="learn",
-    choices=["max", "average", "learn"],
+    choices=["max", "avg", "learn"],
     help="which pooling to use (avg , max or learn)",
 )
 parser.add_argument(
@@ -574,12 +574,6 @@ parser.add_argument(
     help="Factor for OR-Tools, since it only solves integer problems",
 )
 parser.add_argument(
-    "--log_file",
-    type=str,
-    default="/dev/null",
-    help="File to log to, note that visdom produce `jsonl` files, the file is logged in the experiment folder unless it is the `/dev/null` file",
-)
-parser.add_argument(
     "--disable_visdom",
     action="store_true",
     help="Disable visdom logging",
@@ -614,8 +608,3 @@ if args.sample_n_jobs != -1 and args.chunk_n_jobs != -1:
 
 # Sorting the features
 args.features = sorted(args.features)
-
-# Full log path
-args.log_file = (
-    os.path.join(path, args.log_file) if args.log_file != "/dev/null" else args.log_file
-)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,10 +1,27 @@
+import json
+import random
 from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict
 
 from tqdm import tqdm
 
 from args import get_exp_name, get_path
 from instances.generate_taillard import generate_taillard, taillard_to_str
 from train import main
+
+
+def sample_hyperparams(hyperparams: Dict[str, list]) -> Dict[str, Any]:
+    sampled = dict()
+    for key, values in hyperparams.items():
+        sampled[key] = random.choice(values)
+    return sampled
+
+
+def log_hyperparams(hyperparams: Dict[str, Any], logfile: Path):
+    # Save the hyperparams in a json file.
+    with open(logfile, "w") as f:
+        json.dump(hyperparams, f, indent=4)
 
 
 def benchmark_seed(args, n_tries: int):
@@ -80,8 +97,50 @@ def benchmark_small_exp_to_big_exp_generalisation(args, n_tries: int):
         main(args, exp_name, path)
 
 
+def benchmark_dgl_hyperparams(args, n_tries: int):
+    params_space = {
+        "graph_pooling": ["max", "average", "learn"],
+        "layer_pooling": ["last", "all"],
+        "mlp_act_graph": ["relu", "tanh", "gelu", "selu"],
+        "n_mlp_layers_features_extractor": [1, 3, 5],
+        "n_layers_features_extractor": [1, 3, 6, 10],
+        "hidden_dim_features_extractor": [16, 32, 64],
+        "residual_gnn": [True, False],
+        "normalize_gnn": [True, False],
+        "fe_type": ["dgl"],
+        "n_mlp_layers_actor": [1],
+        "n_mlp_layers_critic": [1],
+        "hidden_dim_actor": [32],
+        "hidden_dim_critic": [32],
+        "graph_has_relu": [True],
+    }
+
+    for seed in tqdm(range(n_tries), desc="BENCHMARKING DGL HYPERPARAMS"):
+        args = deepcopy(args)
+
+        setattr(args, "seed", seed)
+
+        # Sample hyperparams.
+        sampled = sample_hyperparams(params_space)
+        for key, value in sampled.items():
+            setattr(args, key, value)
+
+        # Set specific args.
+        setattr(args, "exp_name_appendix", f"dgl-hyperparams_{seed}")
+        exp_name = get_exp_name(args)
+        path = get_path(args.path, exp_name)
+
+        # Save to log files.
+        setattr(args, "log_file", Path(path) / "visdom.jsonl")
+        log_hyperparams(sampled, Path(path) / "hyperparams.json")
+        setattr(args, "disable_visdom", True)
+
+        main(args, exp_name, path)
+
+
 if __name__ == "__main__":
     from args import args
 
     # benchmark_seed(args, 10)
-    benchmark_single_experiment_generalisation(args, 10)
+    # benchmark_single_experiment_generalisation(args, 10)
+    benchmark_dgl_hyperparams(args, 100)

--- a/models/agent_validator.py
+++ b/models/agent_validator.py
@@ -57,7 +57,6 @@ class AgentValidator:
         env_specification,
         device,
         training_specification,
-        log_file,
         disable_visdom,
         verbose=2,
     ):
@@ -86,7 +85,7 @@ class AgentValidator:
         self.fixed_random_validation = training_specification.fixed_random_validation
         self.vis = visdom.Visdom(
             env=training_specification.display_env,
-            log_to_filename=log_file,
+            log_to_filename="/dev/null",
             offline=disable_visdom,
         )
         self.path = training_specification.path
@@ -140,6 +139,8 @@ class AgentValidator:
         self.ep_rew_means = []
         self.fpss = []
         self.dpss = []
+        self.stabilities = []
+        self.monotonies = []
         self.total_timestepss = []
         self.first_callback = True
         self.gantt_rl_img = None
@@ -507,6 +508,8 @@ class AgentValidator:
             )
         )
         self.total_timestepss.append(alg.global_step)
+        self.stabilities.append(alg.logger.name_to_value["train/ratio_stability"])
+        self.monotonies.append(alg.logger.name_to_value["train/ratio_monotony"])
 
         X = list(range(1, len(self.losses) + 1))
         Y_list = [
@@ -534,6 +537,8 @@ class AgentValidator:
             "actions_per_second": self.fpss,
             "updates_per_second": self.dpss,
             "total_timesteps": self.total_timestepss,
+            "ratio_stability": self.stabilities,
+            "ratio_monotony": self.monotonies,
         }
         for title, data in charts.items():
             self.vis.line(X=X, Y=data, win=title, opts={"title": title})

--- a/models/jssp_gnn_dgl.py
+++ b/models/jssp_gnn_dgl.py
@@ -25,17 +25,12 @@
 #
 
 
-from models.mlp import MLP
-import torch
 import dgl
-from dgl.nn import (
-    GINEConv,
-    EGATConv,
-    PNAConv,
-    DGNConv,
-    GCN2Conv,
-)
+import torch
 from dgl import LaplacianPE
+from dgl.nn import DGNConv, EGATConv, GCN2Conv, GINEConv, PNAConv
+
+from models.mlp import MLP
 from utils.jssp_agent_observation import JSSPAgentObservation as AgentObservation
 
 
@@ -57,7 +52,6 @@ class JSSPGnnDGL(torch.nn.Module):
         normalize=False,
         conflicts="att",
     ):
-
         super().__init__()
         self.conflicts = conflicts
         self.residual = residual
@@ -141,7 +135,6 @@ class JSSPGnnDGL(torch.nn.Module):
             # self.mlps_edges = torch.nn.ModuleList()
 
         for layer in range(self.n_layers_features_extractor):
-
             if self.normalize:
                 self.norms.append(torch.nn.BatchNorm1d(self.hidden_dim))
                 if self.residual:
@@ -239,7 +232,6 @@ class JSSPGnnDGL(torch.nn.Module):
                 sys.exit()
 
     def forward(self, obs):
-
         observation = AgentObservation.from_gym_observation(
             obs, conflicts=self.conflicts, max_n_machines=self.max_n_machines
         )
@@ -401,7 +393,7 @@ class JSSPGnnDGL(torch.nn.Module):
             max_elts, max_ind = torch.max(node_features, dim=1)
             graph_embedding = max_elts
         elif self.graph_pooling == "avg":
-            graph_pooling = torch.ones(n_nodes, device=self.device) / n_nodes
+            graph_pooling = torch.ones(n_nodes, device=features.device) / n_nodes
             graph_embedding = torch.matmul(graph_pooling, node_features)
         elif self.graph_pooling == "learn":
             graph_embedding = features[num_nodes : num_nodes + batch_size, :]

--- a/models/psp_agent_validator.py
+++ b/models/psp_agent_validator.py
@@ -10,7 +10,6 @@ class PSPAgentValidator(AgentValidator):
         env_cls,
         device,
         training_specification,
-        log_file,
         disable_visdom,
         verbose=2,
     ):
@@ -20,7 +19,6 @@ class PSPAgentValidator(AgentValidator):
             env_cls,
             device,
             training_specification,
-            log_file,
             disable_visdom,
             verbose=2,
         )

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -12,7 +12,6 @@ def test_validator_psp(
     env_specification_small,
     training_specification,
     psp_agent,
-    log_file,
     disable_visdom,
 ):
     validator = AgentValidator(
@@ -20,7 +19,6 @@ def test_validator_psp(
         env_specification_small,
         torch.device("cpu"),
         training_specification,
-        log_file,
         disable_visdom,
     )
 

--- a/train.py
+++ b/train.py
@@ -217,7 +217,6 @@ def main(args, exp_name, path):
         env_specification,
         args.device,
         training_specification,
-        args.log_file,
         args.disable_visdom,
     )
     ppo = PPO(

--- a/train_psp.py
+++ b/train_psp.py
@@ -202,7 +202,6 @@ def main():
         env_specification,
         args.device,
         training_specification,
-        args.log_file,
         args.disable_visdom,
     )
     ppo = PPO(


### PR DESCRIPTION
Feats:
* Removed the Visdom logfile (`--log_file` is gone).
* Automatically dump the metrics from the SB3 logger to a json file named `progress.json` in the experiment directory.
* Add missing metrics to the logger compared to Visdom (the one that came from the `agent_validator`).
* Add two new metrics: `stability` and `monotony`, which are displayed as an example in the `ratio_stability` and `ratio_monotony` curves on Visdom.
* Catch cuda OOM during benchmarks and record that event.

Fixs:
* Typo in args.py (`average` -> `avg`).
* Device assignment when using `avg` pooling layer. 