### PR TITLE
feat(logs): use torchinfo to plot model trace

### DIFF
--- a/args.py
+++ b/args.py
@@ -591,6 +591,12 @@ parser.add_argument(
     action="store_true",
     help="Do not perform initial eval",
 )
+parser.add_argument(
+    "--skip_model_trace",
+    default=False,
+    action="store_true",
+    help="Do not print the model trace (torchinfo)",
+)
 
 parser.add_argument(
     "--taillard_pbs",

--- a/models/agent.py
+++ b/models/agent.py
@@ -22,11 +22,11 @@
 #
 
 
-import torch
-
-from torch.distributions.categorical import Categorical
 from functools import partial
+
 import numpy as np
+import torch
+from torch.distributions.categorical import Categorical
 
 
 class Agent(torch.nn.Module):
@@ -173,3 +173,8 @@ class Agent(torch.nn.Module):
             mask = info["mask"]
 
         return env.get_solution()
+
+    def forward(self, observation, action=None, action_masks=None, deterministic=False):
+        return self.get_action_and_value(
+            observation, action, action_masks, deterministic
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ matplotlib
 opencv-python
 kaleido
 pandas
+torchinfo

--- a/train.py
+++ b/train.py
@@ -268,6 +268,7 @@ def main(args, exp_name, path):
         rollout_agent_device=args.device,
         opt_state_dict=None,
         skip_initial_eval=args.skip_initial_eval,
+        skip_model_trace=args.skip_model_trace,
     )
 
 

--- a/train_psp.py
+++ b/train_psp.py
@@ -22,10 +22,10 @@
 #
 
 import os
+import random
 
 import numpy as np
 import torch
-import random
 
 from alg.ppo import PPO
 from alg.pretrain import Pretrainer
@@ -250,6 +250,7 @@ def main():
         rollout_agent_device=args.device,
         opt_state_dict=None,
         skip_initial_eval=args.skip_initial_eval,
+        skip_model_trace=args.skip_model_trace,
     )
 
 


### PR DESCRIPTION
The plot is activated by default. Use the arg --skip_model_trace to deactivate it.