### PR TITLE
Handling multiple ortools strategies

### DIFF
--- a/alg/ppo.py
+++ b/alg/ppo.py
@@ -491,7 +491,9 @@ class PPO:
                 )
 
                 ratio_to_ortools = np.array(self.validator.makespans) / np.array(
-                    self.validator.ortools_makespans
+                    self.validator.ortools_makespans[
+                        self.validator.default_ortools_strategy
+                    ]
                 )
                 self.logger.record("train/ratio_monotony", monotony(ratio_to_ortools))
                 self.logger.record("train/ratio_stability", stability(ratio_to_ortools))
@@ -508,21 +510,28 @@ class PPO:
                     "validation/ppo_makespan",
                     self.validator.makespans[-1],
                 )
-                self.logger.record(
-                    "validation/ortools_makespan",
-                    self.validator.ortools_makespans[-1],
-                )
+                for ortools_strategy in self.validator.ortools_strategies:
+                    self.logger.record(
+                        f"validation/ortools_{ortools_strategy}_makespan",
+                        self.validator.ortools_makespans[ortools_strategy][-1],
+                    )
                 self.logger.record(
                     "validation/random_makepsan",
                     self.validator.random_makespans[-1],
                 )
                 self.logger.record(
                     "validation/ratio_to_ortools",
-                    self.validator.makespans[-1] / self.validator.ortools_makespans[-1],
+                    self.validator.makespans[-1]
+                    / self.validator.ortools_makespans[
+                        self.validator.default_ortools_strategy
+                    ][-1],
                 )
                 self.logger.record(
                     "validation/dist_to_ortools",
-                    self.validator.makespans[-1] - self.validator.ortools_makespans[-1],
+                    self.validator.makespans[-1]
+                    - self.validator.ortools_makespans[
+                        self.validator.default_ortools_strategy
+                    ][-1],
                 )
                 for custom_agent in self.validator.custom_agents:
                     name = custom_agent.rule
@@ -533,7 +542,7 @@ class PPO:
                     self.logger.record(
                         f"validation/{name}_ratio_to_ortools",
                         self.validator.custom_makespans[name][-1]
-                        / self.validator.ortools_makespans[-1],
+                        / self.validator.ortools_makespans[self.validator.default_ortools_strategy][-1],
                     )
 
             self.logger.dump(step=self.global_step)

--- a/args.py
+++ b/args.py
@@ -263,7 +263,7 @@ parser.add_argument("--dropout", type=float, default=0.0, help="dropout ratio")
 parser.add_argument(
     "--ortools_strategy",
     type=str,
-    default="averagistic",
+    nargs="*",
     choices=["realistic", "optimistic", "pessimistic", "averagistic"],
     help="ortools durations estimations in pessimistic|optimistic|averagistic|realistic realistic means omiscient, "
     "ie sees the future",
@@ -717,6 +717,12 @@ args.features = sorted(args.features)
 
 if args.custom_heuristic_names is None:
     args.custom_heuristic_names = []
+
+if args.ortools_strategy is None:
+    if args.duration_type == "stochastic":
+        args.ortools_strategy = ["averagistic"]
+    else:
+        args.ortools_strategy = ["realistic"]
 
 if args.resume:
     args.skip_initial_eval = True

--- a/eval.py
+++ b/eval.py
@@ -66,6 +66,7 @@ def load_agent(args: argparse.Namespace, path: str) -> JSSPAgent:
     agent = JSSPAgent.load(path)
     agent.env_specification = env_specification
     agent.agent_specification = agent_specification
+    agent.to(agent_specification.device)
     return agent
 
 
@@ -144,9 +145,12 @@ def eval_on_instances(
 
         perfs[f"{n_j}x{n_m}"] = {
             "PPO": validator.makespans[-1],
-            "OR-tools": validator.ortools_makespans[-1].cpu().item(),
             "Random": validator.random_makespans[-1],
         }
+        for ortools_strategies, values in validator.ortools_makespans.items():
+            perfs[f"{n_j}x{n_m}"][f"OR-Tools - {ortools_strategies}"] = (
+                values[-1].cpu().item()
+            )
         for custom_agent in validator.custom_agents:
             perfs[f"{n_j}x{n_m}"][custom_agent.rule] = validator.custom_makespans[
                 custom_agent.rule

--- a/models/agent_validator.py
+++ b/models/agent_validator.py
@@ -550,16 +550,22 @@ class AgentValidator:
 
         # ratio to OR-tools
         opts = {
-            "title": "PPO / OR-tools",
-            "legend": ["PPO/OR-tools", "Min PPO/OR-tools"],
+            "title": "PPO / OR-Tools",
+            "legend": [],
         }
-        ratio_to_ortools = np.array(self.makespans) / np.array(
-            self.ortools_makespans[self.default_ortools_strategy]
-        )
-        min_ratio_to_ortools = np.minimum.accumulate(ratio_to_ortools)
+        Y_ratios = []
+        for ortools_strategy in self.ortools_strategies:
+            opts["legend"].append(f"PPO/OR-Tools {ortools_strategy}")
+            opts["legend"].append(f"Min PPO/OR-Tools {ortools_strategy}")
+            ratio_to_ortools = np.array(self.makespans) / np.array(
+                self.ortools_makespans[ortools_strategy]
+            )
+            Y_ratios.append(ratio_to_ortools)
+            Y_ratios.append(np.minimum.accumulate(ratio_to_ortools))
+
         self.vis.line(
             X=X,
-            Y=np.stack([ratio_to_ortools, min_ratio_to_ortools], axis=1),
+            Y=np.array(Y_ratios).T,
             win="ratio_to_ortools",
             opts=opts,
         )


### PR DESCRIPTION
The ortools strategy argument can now handle as much strategies as needed. A default strategy is choosen for some metrics (ex: ratio_to_ortools).