### PR TITLE
Pretrain : Visdom plots and evaluation metrics

### DIFF
--- a/alg/ppo.py
+++ b/alg/ppo.py
@@ -229,6 +229,7 @@ class PPO:
         problem_description,
         env_specification,
         lr,
+        weight_decay,
         log_interval=1,
         rollout_data_device=torch.device("cpu"),
         rollout_agent_device=torch.device("cpu"),
@@ -273,8 +274,7 @@ class PPO:
         print("... done creating environments")
 
         self.optimizer = self.optimizer_class(
-            agent.parameters(),
-            lr=lr,
+            agent.parameters(), lr=lr, weight_decay=weight_decay
         )
         if opt_state_dict is not None:
             self.optimizer.load_state_dict(opt_state_dict)
@@ -542,7 +542,9 @@ class PPO:
                     self.logger.record(
                         f"validation/{name}_ratio_to_ortools",
                         self.validator.custom_makespans[name][-1]
-                        / self.validator.ortools_makespans[self.validator.default_ortools_strategy][-1],
+                        / self.validator.ortools_makespans[
+                            self.validator.default_ortools_strategy
+                        ][-1],
                     )
 
             self.logger.dump(step=self.global_step)

--- a/alg/pretrain.py
+++ b/alg/pretrain.py
@@ -149,10 +149,18 @@ class Pretrainer:
         return all_obs, all_masks, all_actions, all_past_actions, pa_to_a, all_makespans
 
     def pretrain(
-        self, agent, num_epochs, minibatch_size, lr=0.0002, vf_coeff: float = 0.01
+        self,
+        agent,
+        num_epochs,
+        minibatch_size,
+        lr=0.0002,
+        vf_coeff: float = 0.01,
+        weight_decay: float = 1e-1,
     ):
         optimizer = self.training_specification.optimizer_class(
-            agent.parameters(), lr=lr
+            agent.parameters(),
+            lr=lr,
+            weight_decay=weight_decay,
         )
 
         (

--- a/alg/pretrain.py
+++ b/alg/pretrain.py
@@ -45,8 +45,14 @@ class Pretrainer:
         num_envs=1,
         num_eval_envs=1,
         trajectories=10,
+        dataset_generation_strategy: str = "online",
         prob=0.9,
     ):
+        assert dataset_generation_strategy in [
+            "offline",
+            "online",
+        ], f"Unknown strategy {dataset_generation_strategy}."
+
         self.problem_description = problem_description
         self.env_specification = env_specification
         self.training_specification = training_specification
@@ -54,6 +60,7 @@ class Pretrainer:
         self.num_envs = num_envs
         self.num_eval_envs = num_eval_envs
         self.trajectories = trajectories
+        self.dataset_generation_strategy = dataset_generation_strategy
         self.prob = prob
 
         self.vis = visdom.Visdom(env=self.training_specification.display_env)
@@ -95,6 +102,12 @@ class Pretrainer:
         return l
 
     def generate_dataset_(self, num_envs: int, trajectories: int) -> tuple:
+        """Generate new dataset by using OR-Tools to solve the envs.
+
+        From each env we generate differents trajectories to account for the fact
+        that a single solution can be derived by many differents decisions.
+        OR-Tools is set to solve with the "averagistic" strategy.
+        """
         all_obs = []
         all_masks = []
         all_actions = []
@@ -109,12 +122,7 @@ class Pretrainer:
             max_completion_time = np.max(env.state.durations)
 
             for _ in tqdm(range(trajectories), desc="Trajectories", leave=False):
-                if self.problem_description.deterministic:
-                    env.reset(soft=True)
-                else:
-                    # WARNING: This works only for fixed problems. There should be
-                    # a way to do this with non-fixed problems.
-                    env.reset()  # Sample new durations within the bounds.
+                env.reset(soft=True)
                 (
                     obs,
                     masks,
@@ -172,7 +180,7 @@ class Pretrainer:
             eval_makespans,
         ) = self.generate_dataset_(self.num_eval_envs, max(self.trajectories // 10, 1))
 
-        for _ in tqdm(range(num_epochs), desc="Pretrain"):
+        if self.dataset_generation_strategy == "offline":
             (
                 train_obs,
                 train_masks,
@@ -182,47 +190,55 @@ class Pretrainer:
                 train_makespans,
             ) = self.generate_dataset_(self.num_envs, self.trajectories)
 
+        for _ in tqdm(range(num_epochs), desc="Pretrain"):
+            if self.dataset_generation_strategy == "online":
+                (
+                    train_obs,
+                    train_masks,
+                    train_actions,
+                    train_past_actions,
+                    train_pa_to_a,
+                    train_makespans,
+                ) = self.generate_dataset_(self.num_envs, self.trajectories)
+
             b_inds = np.arange(len(train_actions))
             np.random.shuffle(b_inds)
 
-            for _ in tqdm(range(3), desc="Sub-epochs", leave=False):
-                a_loss = 0
-                c_loss = 0
-                t_loss = 0
-                for start in tqdm(
-                    range(0, len(train_actions), minibatch_size),
-                    desc="Batches",
-                    leave=False,
-                ):
-                    end = min(start + minibatch_size, len(train_actions))
-                    mb_inds = b_inds[start:end]
+            a_loss = 0
+            c_loss = 0
+            t_loss = 0
+            for start in tqdm(
+                range(0, len(train_actions), minibatch_size),
+                desc="Batches",
+                leave=False,
+            ):
+                end = min(start + minibatch_size, len(train_actions))
+                mb_inds = b_inds[start:end]
 
-                    action_probs, values = agent.get_action_probs_and_value(
-                        get_obs(train_obs, mb_inds), train_masks[mb_inds]
-                    )
-                    target_probs = self.get_target_probs(
-                        train_masks, train_past_actions, train_pa_to_a, mb_inds
-                    ).to(action_probs.device)
-                    loss_actor = torch.nn.functional.mse_loss(
-                        action_probs,
-                        target_probs,
-                        reduction="none",
-                    )
-                    loss_critic = torch.nn.functional.mse_loss(
-                        values.flatten(),
-                        train_makespans[mb_inds].to(values.device).float(),
-                        reduction="none",
-                    )
+                action_probs, values = agent.get_action_probs_and_value(
+                    get_obs(train_obs, mb_inds), train_masks[mb_inds]
+                )
+                target_probs = self.get_target_probs(
+                    train_masks, train_past_actions, train_pa_to_a, mb_inds
+                ).to(action_probs.device)
+                loss_actor = torch.nn.functional.mse_loss(
+                    action_probs,
+                    target_probs,
+                    reduction="none",
+                )
+                loss_critic = torch.nn.functional.mse_loss(
+                    values.flatten(),
+                    train_makespans[mb_inds].to(values.device).float(),
+                    reduction="none",
+                )
 
-                    loss = loss_actor.mean() + vf_coeff * loss_critic.mean()
-                    loss.backward()
-                    optimizer.step()
+                loss = loss_actor.mean() + vf_coeff * loss_critic.mean()
+                loss.backward()
+                optimizer.step()
 
-                    a_loss += loss_actor.sum().item()
-                    c_loss += loss_critic.sum().item()
-                    t_loss += (
-                        loss_actor.sum().item() + vf_coeff * loss_critic.sum().item()
-                    )
+                a_loss += loss_actor.sum().item()
+                c_loss += loss_critic.sum().item()
+                t_loss += loss_actor.sum().item() + vf_coeff * loss_critic.sum().item()
 
             self.train_losses["actor"].append(a_loss / len(train_actions))
             if vf_coeff != 0:

--- a/args.py
+++ b/args.py
@@ -571,6 +571,11 @@ parser.add_argument(
     "--pretrain_prob", type=float, default=0.9, help="target prob for or tools action"
 )
 parser.add_argument(
+    "--pretrain_dataset_generation",
+    default="online",
+    choices=["online", "offline"],
+)
+parser.add_argument(
     "--pretrain_weight_decay",
     type=float,
     default=1e-1,
@@ -615,8 +620,8 @@ parser.add_argument(
 parser.add_argument(
     "--pretrain_vf_coef",
     type=float,
-    default=1e-2,
-    help="value function loss weight",
+    default=0,
+    help="value function loss weight (set to 0 to deactivate)",
 )
 
 

--- a/args.py
+++ b/args.py
@@ -568,7 +568,13 @@ parser.add_argument(
 parser.add_argument(
     "--pretrain_num_envs",
     type=int,
-    default=1,
+    default=100,
+    help="number of pretrain envs (1 is enough for determinisitic case)",
+)
+parser.add_argument(
+    "--pretrain_num_eval_envs",
+    type=int,
+    default=10,
     help="number of pretrain envs (1 is enough for determinisitic case)",
 )
 parser.add_argument(
@@ -582,12 +588,6 @@ parser.add_argument(
     type=int,
     default=128,
     help="size of batch_size for pretrain",
-)
-parser.add_argument(
-    "--pretrain_n_steps_episode",
-    type=int,
-    default=1024,
-    help="pretrain: number of steps per env",
 )
 parser.add_argument(
     "--pretrain_lr",

--- a/args.py
+++ b/args.py
@@ -134,6 +134,12 @@ parser.add_argument(
     help="Which optimizer to use",
 )
 parser.add_argument(
+    "--weight_decay",
+    type=float,
+    default=1e-1,
+    help="PPO weight decay",
+)
+parser.add_argument(
     "--freeze_graph",
     default=False,
     action="store_true",
@@ -564,7 +570,12 @@ parser.add_argument(
 parser.add_argument(
     "--pretrain_prob", type=float, default=0.9, help="target prob for or tools action"
 )
-
+parser.add_argument(
+    "--pretrain_weight_decay",
+    type=float,
+    default=1e-1,
+    help="pretrain weight decay",
+)
 parser.add_argument(
     "--pretrain_num_envs",
     type=int,

--- a/args.py
+++ b/args.py
@@ -147,15 +147,15 @@ parser.add_argument(
 )
 parser.add_argument(
     "--retrain",
-    default=False,
-    action="store_true",
-    help="Use this flag if you want to retrain a pretrained model. The script will look for existing model at path loc.",
+    type=str,
+    default="",
+    help="Use this flag if you want to retrain a trained model. You must provide the direct path to the model you want to load.",
 )
 parser.add_argument(
     "--resume",
     default=False,
     action="store_true",
-    help="Resume a previous training",
+    help="Resume a previous training. The script will look for trained model named \"agent.pkl\" in the directory experiment.",
 )
 
 # =================================================VALIDATION SPECIFICATION=================================================
@@ -576,6 +576,12 @@ parser.add_argument(
     type=int,
     default=10,
     help="number of pretrain envs (1 is enough for determinisitic case)",
+)
+parser.add_argument(
+    "--pretrain_trajectories",
+    type=int,
+    default=10,
+    help="number of trajectories sampled per envs",
 )
 parser.add_argument(
     "--pretrain_epochs",

--- a/args.py
+++ b/args.py
@@ -601,6 +601,12 @@ parser.add_argument(
     default=2e-4,
     help="learning rate for pretrain",
 )
+parser.add_argument(
+    "--pretrain_vf_coef",
+    type=float,
+    default=1e-2,
+    help="value function loss weight",
+)
 
 
 # =================================================OTHER====================================================================

--- a/models/jssp_agent.py
+++ b/models/jssp_agent.py
@@ -135,7 +135,9 @@ class JSSPAgent(Agent):
     @classmethod
     def load(cls, path):
         """Loading an agent corresponds to loading his model and a few args to specify how the model is working"""
-        save_data = torch.load(path + "agent.pkl")
+        if not path.endswith(".pkl"):
+            path = path + "agent.pkl"
+        save_data = torch.load(path)
         agent_specification = save_data["agent_specification"]
         env_specification = save_data["env_specification"]
         if agent_specification.fe_type == "dgl":

--- a/train.py
+++ b/train.py
@@ -243,6 +243,7 @@ def main(args, exp_name, path):
             args.pretrain_epochs,
             args.pretrain_batch_size,
             lr=args.pretrain_lr,
+            vf_coeff=args.pretrain_vf_coef,
         )
 
     # And finally, we train the model on the specified training mode

--- a/train.py
+++ b/train.py
@@ -232,14 +232,15 @@ def main(args, exp_name, path):
             problem_description,
             env_specification,
             training_specification,
+            JSSPEnv,
             num_envs=args.pretrain_num_envs,
+            num_eval_envs=args.pretrain_num_eval_envs,
             prob=args.pretrain_prob,
         )
         pretrainer.pretrain(
             agent,
             args.pretrain_epochs,
             args.pretrain_batch_size,
-            args.pretrain_n_steps_episode,
             lr=args.pretrain_lr,
         )
 

--- a/train.py
+++ b/train.py
@@ -206,9 +206,9 @@ def main(args, exp_name, path):
     )
     agent_specification.print_self()
     # If we want to use a pretrained Agent, we only have to load it (if it exists)
-    if args.retrain and os.path.exists(path + "/agent.pkl"):
+    if args.retrain:
         print("Retraining an already existing agent\n")
-        agent = Agent.load(path)
+        agent = Agent.load(args.retrain)
         agent.env_specification = env_specification
         agent.agent_specification = agent_specification
     elif (
@@ -235,6 +235,7 @@ def main(args, exp_name, path):
             JSSPEnv,
             num_envs=args.pretrain_num_envs,
             num_eval_envs=args.pretrain_num_eval_envs,
+            trajectories=args.pretrain_trajectories,
             prob=args.pretrain_prob,
         )
         pretrainer.pretrain(

--- a/train.py
+++ b/train.py
@@ -244,6 +244,7 @@ def main(args, exp_name, path):
             args.pretrain_batch_size,
             lr=args.pretrain_lr,
             vf_coeff=args.pretrain_vf_coef,
+            weight_decay=args.pretrain_weight_decay,
         )
 
     # And finally, we train the model on the specified training mode
@@ -272,6 +273,7 @@ def main(args, exp_name, path):
         problem_description,
         env_specification,
         lr=args.lr,
+        weight_decay=args.weight_decay,
         log_interval=1,
         train_device=args.device,
         rollout_agent_device=args.device,

--- a/utils/ortools.py
+++ b/utils/ortools.py
@@ -317,6 +317,7 @@ def get_ortools_schedule(
     scaling_constant_ortools=1000,
     ortools_strategy="averagistic",
 ):
+    # TODO: Is it a bug to use the original durations? Edit: Looks OK.
     _, ortools_schedule, optimal = get_ortools_makespan(
         env.state.affectations,
         env.state.original_durations,
@@ -359,14 +360,23 @@ def get_ortools_actions(env, ortools_schedule):
 
 
 def get_ortools_trajectory_and_past_actions(env):
-    schedule, optimal = get_ortools_schedule(env)
+    # print("OR-Tools")
+    # print(env.state.affectations)
+    # print(env.state.durations)
+
+    schedule, optimal = get_ortools_schedule(env, ortools_strategy="realistic")
     # if optimal:
     #     print("using optimal solution from or-tools")
     trajectory = []
     past_actions = []
     obs = []
     masks = []
-    o, info = env.reset()
+    # TODO: Make sure the reset is not sampling new durations, as the schedule would be
+    # based on wrong features for the model. Edit: Looks OK.
+    o, info = env.reset(soft=True)
+    # print("Trajectory")
+    # print(env.state.affectations)
+    # print(env.state.durations, "\n")
     next_obs = obs_as_tensor_add_batch_dim(o)
     action_mask = decode_mask(info["mask"])
     while not env.done():

--- a/utils/ortools.py
+++ b/utils/ortools.py
@@ -318,7 +318,7 @@ def get_ortools_schedule(
     ortools_strategy="averagistic",
 ):
     # TODO: Is it a bug to use the original durations? Edit: Looks OK.
-    _, ortools_schedule, optimal = get_ortools_makespan(
+    makespan, ortools_schedule, optimal = get_ortools_makespan(
         env.state.affectations,
         env.state.original_durations,
         env.env_specification.n_features,
@@ -326,7 +326,7 @@ def get_ortools_schedule(
         scaling_constant_ortools,
         ortools_strategy,
     )
-    return ortools_schedule, optimal
+    return makespan, ortools_schedule, optimal
 
 
 def get_ortools_actions(env, ortools_schedule):
@@ -364,7 +364,9 @@ def get_ortools_trajectory_and_past_actions(env):
     # print(env.state.affectations)
     # print(env.state.durations)
 
-    schedule, optimal = get_ortools_schedule(env, ortools_strategy="realistic")
+    makespan, schedule, optimal = get_ortools_schedule(
+        env, ortools_strategy="realistic"
+    )
     # if optimal:
     #     print("using optimal solution from or-tools")
     trajectory = []
@@ -390,4 +392,4 @@ def get_ortools_trajectory_and_past_actions(env):
         next_obs = obs_as_tensor_add_batch_dim(next_obs)
         past_actions.append(trajectory.copy())
         trajectory.append(action)
-    return obs, masks, trajectory, past_actions
+    return obs, masks, trajectory, past_actions, makespan

--- a/utils/ortools.py
+++ b/utils/ortools.py
@@ -360,25 +360,18 @@ def get_ortools_actions(env, ortools_schedule):
 
 
 def get_ortools_trajectory_and_past_actions(env):
-    # print("OR-Tools")
-    # print(env.state.affectations)
-    # print(env.state.durations)
-
     makespan, schedule, optimal = get_ortools_schedule(
-        env, ortools_strategy="realistic"
+        env, ortools_strategy="averagistic"
     )
-    # if optimal:
-    #     print("using optimal solution from or-tools")
+
     trajectory = []
     past_actions = []
     obs = []
     masks = []
-    # TODO: Make sure the reset is not sampling new durations, as the schedule would be
-    # based on wrong features for the model. Edit: Looks OK.
+
+    # Reset the env but do not sample a new problem.
     o, info = env.reset(soft=True)
-    # print("Trajectory")
-    # print(env.state.affectations)
-    # print(env.state.durations, "\n")
+
     next_obs = obs_as_tensor_add_batch_dim(o)
     action_mask = decode_mask(info["mask"])
     while not env.done():
@@ -386,7 +379,6 @@ def get_ortools_trajectory_and_past_actions(env):
         masks.append(action_mask)
         actions = get_ortools_actions(env, schedule)
         action = np.random.choice(actions)
-        # action = actions[0]
         next_obs, reward, done, _, info = env.step(action)
         action_mask = decode_mask(info["mask"])
         next_obs = obs_as_tensor_add_batch_dim(next_obs)


### PR DESCRIPTION
Use OR-Tools to provide a training set to serve as a base for the policy to imitate. OR-Tools is set to solve the problem using the `averagistic` strategy.

- Follow actor train/eval loss during pretraining on visdom.
- Able to pretrain on a specific instances and finetune the model using PPO onto those specific instances. To do this you have to make sure to mark the instances as fixed for both training and validation.
- New training set can be generated "online" for each new epoch or "offline" at the start of the pretraining phase. For fixed problem, the generation should be offline since the solutions would be the same everytime they are solved. Either way, you have to specify the generation strategy in the arguments.
- Best pretrained model (based on its evaluation loss) is saved locally to a file named `pretrain.pkl` in the training directory path.
- Added a `--retrain PATH` argument, that load the weights of the model pointed by the `PATH` value. This is slightly different than the actual `--resume` that simply load the weights of the `agent.pkl` in the current training directory path.
- Added weight decay for pretraining and for PPO training. The two corresponding args are `--pretrain_weight_decay` and `--weight_decay`.
- Code for training the critic is provided but deactivated if the critic loss coefficient is set to $0$. This part of the pretraining is not validated and should be tested further to make sure it is useful.
- Fixed some bugs in the pretraining loop.

Example of args to test:

```py
python3 train.py --n_j 4 --n_m 4 --max_n_j 20 --max_n_m 20 --total_timesteps 100000000000 --n_validation_env 50 --fixed_validation --n_steps_episode 160 --n_workers 10 --batch_size 160 --lr 1e-4 --exp_name_appendix pretrain --seed 1 --optimizer adam --target_kl 0.04 --ent_coef 0.05 --n_epochs 20 --device cuda:0 --fe_type dgl --residual_gnn --graph_has_relu --graph_pooling learn --hidden_dim_features_extractor 32 --n_layers_features_extractor 5 --mlp_act gelu --layer_pooling last --n_mlp_layers_features_extractor 1 --n_mlp_layers_actor 1 --n_mlp_layers_critic 1 --hidden_dim_actor 16 --hidden_dim_critic 16 --pretrain --pretrain_num_envs 100 --pretrain_num_eval_envs 10 --pretrain_dataset_generation online --pretrain_prob 0.9 --pretrain_epochs 100 --pretrain_batch_size 128 --pretrain_lr 1e-5 --pretrain_weight_decay 1e-1
```