### PR TITLE
Problem resets and generation

### DIFF
--- a/env/jssp_env.py
+++ b/env/jssp_env.py
@@ -22,31 +22,30 @@
 #
 
 import gymnasium as gym
-from gymnasium.spaces import Discrete, Dict, Box
 import numpy as np
+from gymnasium.spaces import Box, Dict, Discrete
 
+from env.jssp_state import JSSPState as State
+from env.reward_models.intrinsic_reward_model import IntrinsicRewardModel
+from env.reward_models.l2d_estim_reward_model import L2DEstimRewardModel
+from env.reward_models.l2d_reward_model import L2DRewardModel
+from env.reward_models.meta_reward_model import MetaRewardModel
+from env.reward_models.sparse_reward_model import SparseRewardModel
+from env.reward_models.tassel_reward_model import TasselRewardModel
+from env.reward_models.uncertain_reward_model import UncertainRewardModel
 from env.transition_models.l2d_transition_model import L2DTransitionModel
 from env.transition_models.simple_transition_model import SimpleTransitionModel
 from env.transition_models.slot_locking_transition_model import (
     SlotLockingTransitionModel,
 )
-from env.reward_models.intrinsic_reward_model import IntrinsicRewardModel
-from env.reward_models.l2d_reward_model import L2DRewardModel
-from env.reward_models.l2d_estim_reward_model import L2DEstimRewardModel
-from env.reward_models.meta_reward_model import MetaRewardModel
-from env.reward_models.sparse_reward_model import SparseRewardModel
-from env.reward_models.tassel_reward_model import TasselRewardModel
-from env.reward_models.uncertain_reward_model import UncertainRewardModel
 from utils.jssp_env_observation import JSSPEnvObservation as EnvObservation
-from env.jssp_state import JSSPState as State
 
 
 class JSSPEnv(gym.Env):
-    def __init__(self, problem_description, env_specification, seed: int, validate=False):
+    def __init__(self, problem_description, env_specification, i=0, validate=False):
         self.problem_description = problem_description
         self.env_specification = env_specification
-        self.seed = seed
-        self.rng = np.random.default_rng(seed)
+        self.rng = problem_description.rng
         self.sum_reward = 0
 
         self.transition_model_config = problem_description.transition_model_config

--- a/env/jssp_env.py
+++ b/env/jssp_env.py
@@ -42,9 +42,11 @@ from env.jssp_state import JSSPState as State
 
 
 class JSSPEnv(gym.Env):
-    def __init__(self, problem_description, env_specification, i, validate=False):
+    def __init__(self, problem_description, env_specification, seed: int, validate=False):
         self.problem_description = problem_description
         self.env_specification = env_specification
+        self.seed = seed
+        self.rng = np.random.default_rng(seed)
         self.sum_reward = 0
 
         self.transition_model_config = problem_description.transition_model_config
@@ -236,7 +238,7 @@ class JSSPEnv(gym.Env):
         if chunk == -1:
             return input_affectations, input_durations
         assert chunk <= self.problem_description.n_jobs
-        start = np.random.randint(self.problem_description.n_jobs - chunk + 1)
+        start = self.rng.integers(self.problem_description.n_jobs - chunk + 1)
         affectations = input_affectations[start : start + chunk]
         durations = input_durations[start : start + chunk]
         return affectations, durations
@@ -248,14 +250,14 @@ class JSSPEnv(gym.Env):
             return input_affectations, input_durations
         assert sample <= self.problem_description.n_jobs
         ids = list(range(len(input_durations)))
-        samples = np.random.choice(ids, sample, replace=False)
+        samples = self.rng.choice(ids, sample, replace=False)
         self.sampled_jobs = samples
         affectations = np.array([input_affectations[i] for i in samples])
         durations = np.array([input_durations[i] for i in samples])
         return affectations, durations
 
     def _create_state(self):
-        affectations, durations = self.problem_description.sample_problem()
+        affectations, durations = self.problem_description.sample_problem(self.rng)
         affectations, durations = self.sample_jobs(affectations, durations)
         affectations, durations = self.chunk_jobs(affectations, durations)
         self.state = State(

--- a/models/agent_validator.py
+++ b/models/agent_validator.py
@@ -127,15 +127,21 @@ class AgentValidator:
         else:
             aff = [[0]] * self.n_validation_env
 
-        self.validation_envs = [
-            self.env_cls(
-                self.problem_description,
-                self.env_specification,
-                aff[i],
-                validate=True,
+        self.validation_envs = []
+        for i in range(self.n_validation_env):
+            problem_description = copy.deepcopy(self.problem_description)
+            problem_description.rng = np.random.default_rng(
+                self.problem_description.seed + i
             )
-            for i in range(self.n_validation_env)
-        ]
+            self.validation_envs.append(
+                self.env_cls(
+                    problem_description,
+                    self.env_specification,
+                    aff[i],
+                    validate=True,
+                )
+            )
+
         self.makespan_ratio = 1000
         self.makespans = []
         self.ortools_makespans = {

--- a/problem/jssp_description.py
+++ b/problem/jssp_description.py
@@ -58,7 +58,8 @@ class JSSPDescription:
          - Any problem, deterministic: specify n_jobs, n_machines, max_duration
          - Any problem, stochastic: Specify n_jobs, n_machines, duration_mode_bound, duration_delta
         """
-        rng = np.random.default_rng(seed)
+        self.seed = seed
+        self.rng = np.random.default_rng(seed)
 
         # Checking the consistency of the inputs
         self.check_consistency(affectations, durations, n_jobs, n_machines)
@@ -86,7 +87,7 @@ class JSSPDescription:
                         "Please provide max_duration to generate a deterministic problem"
                     )
                 self.affectations, self.durations = generate_deterministic_problem(
-                    self.n_jobs, self.n_machines, max_duration, rng
+                    self.n_jobs, self.n_machines, max_duration, self.rng
                 )
             self.deterministic = True
             self.fixed = True
@@ -114,10 +115,14 @@ class JSSPDescription:
                         "Please provide duration_mode_bounds and duration_delta to generate a stochastic problem"
                     )
                 self.affectations, self.durations = generate_problem_distrib(
-                    self.n_jobs, self.n_machines, duration_mode_bounds, duration_delta, rng
+                    self.n_jobs,
+                    self.n_machines,
+                    duration_mode_bounds,
+                    duration_delta,
+                    self.rng,
                 )
             # Generate a first version of the durations, to have a totally instantiated duration
-            self.durations = generate_problem_durations(self.durations, rng)
+            self.durations = generate_problem_durations(self.durations, self.rng)
             # But we still want to regenerate durations at each sampling. This can be deactivated for totally fixed problem
             self.regenerate_durations = True
 
@@ -211,7 +216,9 @@ class JSSPDescription:
                 return self.affectations, self.durations
             else:
                 if self.regenerate_durations:
-                    return self.affectations, generate_problem_durations(self.durations, rng)
+                    return self.affectations, generate_problem_durations(
+                        self.durations, rng
+                    )
                 else:
                     return self.affectations, self.durations
         else:

--- a/test/test_jssp_env.py
+++ b/test/test_jssp_env.py
@@ -47,7 +47,7 @@ def test_resets():
     # Test the soft scenarios.
     for deterministic, fixed in product([True, False], [True, False]):
         env_specification, problem_description = init_specs(deterministic, fixed)
-        env = JSSPEnv(problem_description, env_specification, 0)
+        env = JSSPEnv(problem_description, env_specification)
         affectations = env.state.affectations.copy()
         durations = env.state.original_durations.copy()
 
@@ -58,7 +58,7 @@ def test_resets():
     # Not fixed problems & hard resets.
     for deterministic in [True, False]:
         env_specification, problem_description = init_specs(deterministic, False)
-        env = JSSPEnv(problem_description, env_specification, 0)
+        env = JSSPEnv(problem_description, env_specification)
         affectations = env.state.affectations.copy()
         durations = env.state.original_durations.copy()
 
@@ -74,7 +74,7 @@ def test_resets():
     # Fixed problems and hard resets.
     for deterministic in [True, False]:
         env_specification, problem_description = init_specs(deterministic, True)
-        env = JSSPEnv(problem_description, env_specification, 0)
+        env = JSSPEnv(problem_description, env_specification)
         affectations = env.state.affectations.copy()
         durations = env.state.original_durations.copy()
 
@@ -127,16 +127,16 @@ def test_problem_generation(seed: int):
 
     for deterministic, fixed in product([False, True], [False, True]):
         env_specification, problem_description = init_specs(deterministic, fixed, seed)
-        env = JSSPEnv(problem_description, env_specification, seed)
+        env = JSSPEnv(problem_description, env_specification)
         affectations = env.state.affectations.copy()
         durations = env.state.original_durations.copy()
 
         env_specification, problem_description = init_specs(deterministic, fixed, seed)
-        env = JSSPEnv(problem_description, env_specification, seed)
+        env = JSSPEnv(problem_description, env_specification)
         assert np.all(env.state.affectations == affectations), "Affectations changed"
         assert np.all(env.state.original_durations == durations), "Durations changed"
 
         env_specification, problem_description = init_specs(deterministic, fixed, seed + 1)
-        env = JSSPEnv(problem_description, env_specification, seed + 1)
+        env = JSSPEnv(problem_description, env_specification)
         assert np.any(env.state.affectations != affectations), "Affectations unchanged"
         assert np.any(env.state.original_durations != durations), "Durations unchanged"

--- a/test_jssp_env.py
+++ b/test_jssp_env.py
@@ -8,8 +8,6 @@ from env.jssp_env_specification import JSSPEnvSpecification
 from problem.jssp_description import JSSPDescription
 
 
-# TODO: Test resets
-# - Find a way to reset a non-fixed stochastic problem with a resample of the real durations only.
 def test_resets():
     """Test the env resets.
 
@@ -42,6 +40,7 @@ def test_resets():
             n_jobs=10,
             n_machines=10,
             max_duration=99,
+            seed=0,
         )
         return env_specification, problem_description
 
@@ -94,5 +93,50 @@ def test_resets():
             ), "Real durations unchanged"
 
 
-# TODO: Problem generation
-# - Make sure the seed is completely defining the generated problem.
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4, 5])
+def test_problem_generation(seed: int):
+    """Make sure the seed is completely defining the generated problem."""
+
+    def init_specs(deterministic: bool, fixed: bool, seed: int):
+        env_specification = JSSPEnvSpecification(
+            max_n_jobs=10,
+            max_n_machines=10,
+            normalize_input=True,
+            input_list=["duration"],
+            insertion_mode="no_forced_insertion",
+            max_edges_factor=4,
+            sample_n_jobs=-1,
+            chunk_n_jobs=-1,
+            observe_conflicts_as_cliques=True,
+            observe_real_duration_when_affect=False,
+            do_not_observe_updated_bounds=False,
+        )
+        problem_description = JSSPDescription(
+            deterministic=deterministic,
+            fixed=fixed,
+            transition_model_config="simple",
+            reward_model_config="Sparse",
+            duration_mode_bounds=(10, 50),
+            duration_delta=(10, 200),
+            n_jobs=10,
+            n_machines=10,
+            max_duration=99,
+            seed=seed,
+        )
+        return env_specification, problem_description
+
+    for deterministic, fixed in product([False, True], [False, True]):
+        env_specification, problem_description = init_specs(deterministic, fixed, seed)
+        env = JSSPEnv(problem_description, env_specification, seed)
+        affectations = env.state.affectations.copy()
+        durations = env.state.original_durations.copy()
+
+        env_specification, problem_description = init_specs(deterministic, fixed, seed)
+        env = JSSPEnv(problem_description, env_specification, seed)
+        assert np.all(env.state.affectations == affectations), "Affectations changed"
+        assert np.all(env.state.original_durations == durations), "Durations changed"
+
+        env_specification, problem_description = init_specs(deterministic, fixed, seed + 1)
+        env = JSSPEnv(problem_description, env_specification, seed + 1)
+        assert np.any(env.state.affectations != affectations), "Affectations unchanged"
+        assert np.any(env.state.original_durations != durations), "Durations unchanged"

--- a/test_jssp_env.py
+++ b/test_jssp_env.py
@@ -1,0 +1,98 @@
+from itertools import product
+
+import numpy as np
+import pytest
+
+from env.jssp_env import JSSPEnv
+from env.jssp_env_specification import JSSPEnvSpecification
+from problem.jssp_description import JSSPDescription
+
+
+# TODO: Test resets
+# - Find a way to reset a non-fixed stochastic problem with a resample of the real durations only.
+def test_resets():
+    """Test the env resets.
+
+    - Soft reset: change nothing.
+    - Hard reset and not fixed problem: change everything.
+    - Hard reset and fixed problem: sample new real durations only (stochastic).
+    """
+
+    def init_specs(deterministic: bool, fixed: bool):
+        env_specification = JSSPEnvSpecification(
+            max_n_jobs=10,
+            max_n_machines=10,
+            normalize_input=True,
+            input_list=["duration"],
+            insertion_mode="no_forced_insertion",
+            max_edges_factor=4,
+            sample_n_jobs=-1,
+            chunk_n_jobs=-1,
+            observe_conflicts_as_cliques=True,
+            observe_real_duration_when_affect=False,
+            do_not_observe_updated_bounds=False,
+        )
+        problem_description = JSSPDescription(
+            deterministic=deterministic,
+            fixed=fixed,
+            transition_model_config="simple",
+            reward_model_config="Sparse",
+            duration_mode_bounds=(10, 50),
+            duration_delta=(10, 200),
+            n_jobs=10,
+            n_machines=10,
+            max_duration=99,
+        )
+        return env_specification, problem_description
+
+    # Test the soft scenarios.
+    for deterministic, fixed in product([True, False], [True, False]):
+        env_specification, problem_description = init_specs(deterministic, fixed)
+        env = JSSPEnv(problem_description, env_specification, 0)
+        affectations = env.state.affectations.copy()
+        durations = env.state.original_durations.copy()
+
+        env.reset(soft=True)
+        assert np.all(affectations == env.state.affectations), "Affectations changed"
+        assert np.all(durations == env.state.original_durations), "Durations changed"
+
+    # Not fixed problems & hard resets.
+    for deterministic in [True, False]:
+        env_specification, problem_description = init_specs(deterministic, False)
+        env = JSSPEnv(problem_description, env_specification, 0)
+        affectations = env.state.affectations.copy()
+        durations = env.state.original_durations.copy()
+
+        env.reset(soft=False)
+        assert np.any(affectations != env.state.affectations), "Affectations unchanged"
+        assert np.any(
+            durations[:, :, 1:] != env.state.original_durations[:, :, 1:]
+        ), "Bornes unchanged"
+        assert np.any(
+            durations[:, :, 0] != env.state.original_durations[:, :, 0]
+        ), "Real durations unchanged"
+
+    # Fixed problems and hard resets.
+    for deterministic in [True, False]:
+        env_specification, problem_description = init_specs(deterministic, True)
+        env = JSSPEnv(problem_description, env_specification, 0)
+        affectations = env.state.affectations.copy()
+        durations = env.state.original_durations.copy()
+
+        env.reset(soft=False)
+        assert np.any(affectations == env.state.affectations), "Affectations unchanged"
+        assert np.any(
+            durations[:, :, 1:] == env.state.original_durations[:, :, 1:]
+        ), "Bornes unchanged"
+        if deterministic:
+            assert np.any(
+                durations[:, :, 0] == env.state.original_durations[:, :, 0]
+            ), "Real durations changed"
+        else:
+            assert np.any(
+                durations[:, :, 0] != env.state.original_durations[:, :, 0]
+            ), "Real durations unchanged"
+
+
+# TODO: Problem generation
+# - Make sure the seed is completely defining the generated problem.

--- a/train.py
+++ b/train.py
@@ -74,6 +74,7 @@ def main(args, exp_name, path):
         max_duration=args.max_duration,
         duration_mode_bounds=args.duration_mode_bounds,
         duration_delta=args.duration_delta,
+        seed=args.seed,
     )
     problem_description.print_self()
 
@@ -99,6 +100,7 @@ def main(args, exp_name, path):
             max_duration=args.max_duration,
             duration_mode_bounds=args.duration_mode_bounds,
             duration_delta=args.duration_delta,
+            seed=args.seed,
         )
 
     # Then specify the variables used for the training

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -84,6 +84,7 @@ def generate_deterministic_problem(n_jobs, n_machines, high):
     Note that durations is of shape[n_jobs, n_machines, 4], but its only 4 repetitions of an array of shape
     [n_jobs, n_machines]
     """
+    assert high is not None, "High is None"
     durations = np.random.randint(low=1, high=high, size=(n_jobs, n_machines, 1))
     durations = np.repeat(durations, repeats=4, axis=2)
     affectations = np.expand_dims(np.arange(0, n_machines), axis=0)


### PR DESCRIPTION
Unit tests to make sure the problem resets and generations are working properly.

Added a seed for the jssp problem description, that has to be specified so that we make sure that each env is deterministically generated, and reproducible across trainings. This is pretty useful if we want to retrain a model on the same random problems.