### PR TITLE
fix(psp): null durations in stochastic psp

### DIFF
--- a/psp/env/state.py
+++ b/psp/env/state.py
@@ -120,7 +120,17 @@ class State:
             return durs[:, 0]
         else:
             d = np.zeros((durs.shape[0]))
-            r = np.random.triangular(durs[1:-1, 1], durs[1:-1, 0], durs[1:-1, 2])
+
+            # fixing null durations
+            null_durations = np.where(durs[1:-1, 1] == durs[1:-1, 2])
+            fixed_durs = durs[1:-1, 2].copy()
+            fixed_durs[null_durations] = 1e-6
+            
+            r = np.random.triangular(durs[1:-1,1], durs[1:-1,0], fixed_durs)
+
+            # reinstating null durations
+            durs[1:-1, 2][null_durations] = 0
+            
             d[1:-1] = r
             return d
 

--- a/psp/utils/ortools.py
+++ b/psp/utils/ortools.py
@@ -28,8 +28,30 @@ import collections
 from ortools.sat.python import cp_model
 from copy import deepcopy
 import numpy as np
+from operator import itemgetter
 from psp.solution import Solution
 
+def node_from_job_mode(problem, jobid, modeid):
+    nid = 0
+    for i in range(jobid):
+        nid += problem["job_info"][i][0]
+    return nid + modeid
+
+def compute_ortools_makespan_on_real_duration(solution, state):
+    state.reset()  # reset do not redraw real durations
+
+    aff = solution.job_schedule
+    mid = solution.modes
+    while True:
+        index, element = min(enumerate(aff), key=itemgetter(1))
+        if element == float("inf"):
+            break
+        modeid = mid[index]
+        aff[index] = float("inf")
+        nid = node_from_job_mode(state.problem, index, modeid)
+        state.affect_job(node_from_job_mode(state.problem, index, modeid))
+
+    return state.tct_real(-1), state.all_tct_real() - state.all_duration_real()
 
 def get_ortools_makespan_psp(
     env,


### PR DESCRIPTION
This PR fixes solving psp with `--generate_duration_bounds` and `--duration_type stochastic` by working around null durations (dummy actions).