### PR TITLE
Provide an easy way to use a trained model for inference

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,17 @@ Commmon options:
 - `--exp_name_appendix` : print suffix for  visdom
 
 
+Once a model is trained, you can use it to solve new problems using:
+```sh
+python3 -m jssp.solve\
+    --path "./PATH/TO/EXPERIMENT/"\
+    --load_problem "./PATH/TO/INSTANCE.TXT"\
+    [--first_machine_id_is_one]  # Optional, if you load taillard problems, you should tell that the index starts at one.
+```
+
+See `jssp/solve.py` to see how to load and use the model in your own python scripts.
+
+
 
 # Small fixed random problem without uncertainty
 

--- a/jssp/solution.py
+++ b/jssp/solution.py
@@ -25,6 +25,8 @@
 #
 
 import numpy as np
+from pathlib import Path
+from typing import Union
 
 
 class Solution:
@@ -34,3 +36,6 @@ class Solution:
 
     def get_makespan(self):
         return np.max(self.schedule + self.real_durations)
+
+    def save(self, path: Union[Path, str]):
+        np.savetxt(path, self.schedule, fmt="%d")

--- a/jssp/solve.py
+++ b/jssp/solve.py
@@ -1,0 +1,78 @@
+"""Use a trained model to solve a given JSSP problem."""
+from pathlib import Path
+
+import numpy as np
+
+from generic.utils import decode_mask
+from jssp.description import Description
+from jssp.env.env import Env
+from jssp.models.agent import Agent
+from jssp.solution import Solution
+
+
+def solve_instance(
+    agent: Agent,
+    affectations: np.ndarray,
+    durations: np.ndarray,
+    deterministic: bool,
+) -> Solution:
+    problem_description = Description(
+        transition_model_config="simple",
+        reward_model_config="Sparse",
+        deterministic=deterministic,
+        fixed=True,
+        seed=0,
+        affectations=affectations,
+        durations=durations,
+    )
+    env_specification = agent.env_specification
+    env = Env(problem_description, env_specification)
+
+    done = False
+    obs, info = env.reset(soft=True)
+    while not done:
+        action_masks = decode_mask(info["mask"])
+        obs = agent.obs_as_tensor_add_batch_dim(obs)
+        action = agent.predict(obs, deterministic=True, action_masks=action_masks)
+        obs, reward, done, _, info = env.step(action.long().item())
+        solution = env.get_solution()
+
+    return solution
+
+
+if __name__ == "__main__":
+    from args import argument_parser, parse_args
+    from jssp.utils.loaders import load_problem
+
+    parser = argument_parser()
+    args, _, _ = parse_args(parser)
+
+    assert (
+        args.load_problem is not None
+    ), "You should provide a problem to solve (use --load_problem)."
+
+    agent = Agent.load(args.path)
+    n_j, n_m, affectations, durations = load_problem(
+        args.load_problem,
+        taillard_offset=args.first_machine_id_is_one,
+        deterministic=args.duration_type == "deterministic",
+    )
+
+    print(f"Solving a {n_j}x{n_m} JSSP instance.")
+
+    assert (
+        agent.env_specification.max_n_jobs >= n_j
+    ), f"Too many jobs for the agent ({agent.env_specification.max_n_jobs} vs {n_j})."
+    assert (
+        agent.env_specification.max_n_machines >= n_m
+    ), f"Too many jobs for the agent ({agent.env_specification.max_n_machines} vs {n_m})."
+
+    solution = solve_instance(
+        agent, affectations, durations, args.duration_type == "deterministic"
+    )
+    print(f"Makespan: {solution.get_makespan()}")
+
+    problem_name = Path(args.load_problem).stem
+    solution_filepath = Path("./") / f"{problem_name}_solution.txt"
+    solution.save(solution_filepath)
+    print(f"Schedule saved to {solution_filepath}")

--- a/jssp/utils/loaders.py
+++ b/jssp/utils/loaders.py
@@ -25,6 +25,7 @@
 import numpy as np
 import pathlib
 import glob
+from jssp.utils.utils import check_sanity
 
 
 def load_problem(


### PR DESCRIPTION
To do inference with a trained JSSP model, you can now use the script located at `jssp/solve.py`. Should solve #75 .

Exemple of args:
```py
python3 -m jssp.solve\
    --path "./PATH/TO/EXPERIMENT/"\
    -- load_problem "./PATH/TO/EXPERIMENT.TXT"\
    [--first_machine_id_is_one]  # Optional, if you load taillard problems, you should tell that the index starts at one.
```

The schedule will be saved locally and the makespan will be printed on stdout.