### PR TITLE
chore(ml): GAE is off by default (lambda = 1.0)

### DIFF
--- a/args.py
+++ b/args.py
@@ -133,7 +133,7 @@ def argument_parser() -> argparse.ArgumentParser:
         help="RPO-style smoothing param",
     )
     parser.add_argument(
-        "--gae_lambda", type=float, default=0.95, help="GAE lambda param"
+        "--gae_lambda", type=float, default=1.0, help="GAE lambda parameter, GAE off by default"
     )
     parser.add_argument(
         "--return_based_scaling",

--- a/tests/test_jssp.py
+++ b/tests/test_jssp.py
@@ -36,7 +36,7 @@ possible_args = {
     "vf_coef": [1.0],
     "clip_range": [0.25],
     "gamma": [1.0],
-    "gae_lambda": [0.99],
+    "gae_lambda": [1.0],
     "optimizer": ["adamw"],
     "fe_type": ["dgl"],
     "residual_gnn": [True],

--- a/tests/test_psp.py
+++ b/tests/test_psp.py
@@ -240,7 +240,7 @@ possible_args = {
     "vf_coef": [1.0],
     "clip_range": [0.25],
     "gamma": [1.0],
-    "gae_lambda": [0.99],
+    "gae_lambda": [1.0],
     "optimizer": ["adamw"],
     "fe_type": ["dgl"],
     "residual_gnn": [True],


### PR DESCRIPTION
GAE lambda set to 0.95 is detrimental vs 1.0 in most of our tests.