### PR TITLE
Observation horizon, subgraphs as obs and fast forward

### DIFF
--- a/alg/ppo.py
+++ b/alg/ppo.py
@@ -332,9 +332,11 @@ class PPO:
                     for i in range(self.num_envs)
                 ],
                 # spwan helps when observation space is huge
-                # context="spawn",
+                # and also with torch in subprocesses
+                context="spawn",
                 copy=False,
                 shared_memory=True,
+                disk=True,
             )
 
         print("... done creating environments")

--- a/args.py
+++ b/args.py
@@ -451,6 +451,13 @@ def argument_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--observe_subgraph",
+        default=False,
+        action="store_true",
+        help="extract subgraph (graphgym only ATM)",
+    )
+
+    parser.add_argument(
         "--vnode", default=False, action="store_true", help="add vnode to MP-graph"
     )
 

--- a/args.py
+++ b/args.py
@@ -133,7 +133,10 @@ def argument_parser() -> argparse.ArgumentParser:
         help="RPO-style smoothing param",
     )
     parser.add_argument(
-        "--gae_lambda", type=float, default=1.0, help="GAE lambda parameter, GAE off by default"
+        "--gae_lambda",
+        type=float,
+        default=1.0,
+        help="GAE lambda parameter, GAE off by default",
     )
     parser.add_argument(
         "--return_based_scaling",
@@ -428,6 +431,25 @@ def argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="keep past precedencies",
     )
+    parser.add_argument(
+        "--observation_horizon_step",
+        default=0,
+        type=int,
+        help="observation horizon (steps)",
+    )
+    parser.add_argument(
+        "--observation_horizon_time",
+        default=0,
+        type=float,
+        help="observation horizon (time)",
+    )
+    parser.add_argument(
+        "--no_fast_forward",
+        default=False,
+        action="store_true",
+        help="do not make env auto forward trivial actions",
+    )
+
     parser.add_argument(
         "--vnode", default=False, action="store_true", help="add vnode to MP-graph"
     )

--- a/psp/env/env_specification.py
+++ b/psp/env/env_specification.py
@@ -44,6 +44,9 @@ class EnvSpecification:
         factored_rp,
         remove_old_resource_info,
         remove_past_prec,
+        observation_horizon_step,
+        observation_horizon_time,
+        fast_forward,
     ):
         self.problems = problems
         self.max_n_modes = self.problems.max_n_modes
@@ -72,6 +75,9 @@ class EnvSpecification:
         self.action_space = Discrete(self.max_n_nodes)
         self.remove_old_resource_info = remove_old_resource_info
         self.remove_past_prec = remove_past_prec
+        self.observation_horizon_step = observation_horizon_step
+        self.observation_horizon_time = observation_horizon_time
+        self.fast_forward = fast_forward
 
         if self.max_edges_factor > 0:
             self.shape_pr = (
@@ -210,6 +216,9 @@ class EnvSpecification:
             f"add resource prcedence edges:       {self.add_rp_edges}\n"
             f"remove old resource info:           {self.remove_old_resource_info}\n"
             f"remove past prec:                   {self.remove_past_prec}\n"
+            f"observation horizon step:           {self.observation_horizon_step}\n"
+            f"observation horizon time:           {self.observation_horizon_time}\n"
+            f"fast forward:                       {self.fast_forward}\n"
             f"List of features:\n - Task Completion Times\n - selectable\n - duration"
         )
 

--- a/psp/env/env_specification.py
+++ b/psp/env/env_specification.py
@@ -47,6 +47,7 @@ class EnvSpecification:
         observation_horizon_step,
         observation_horizon_time,
         fast_forward,
+        observe_subgraph,
     ):
         self.problems = problems
         self.max_n_modes = self.problems.max_n_modes
@@ -78,6 +79,7 @@ class EnvSpecification:
         self.observation_horizon_step = observation_horizon_step
         self.observation_horizon_time = observation_horizon_time
         self.fast_forward = fast_forward
+        self.observe_subgraph = observe_subgraph
 
         if self.max_edges_factor > 0:
             self.shape_pr = (
@@ -219,6 +221,7 @@ class EnvSpecification:
             f"observation horizon step:           {self.observation_horizon_step}\n"
             f"observation horizon time:           {self.observation_horizon_time}\n"
             f"fast forward:                       {self.fast_forward}\n"
+            f"observe subgraph:                   {self.observe_subgraph}\n"
             f"List of features:\n - Task Completion Times\n - selectable\n - duration"
         )
 

--- a/psp/env/graphgym/async_vector_env.py
+++ b/psp/env/graphgym/async_vector_env.py
@@ -1,6 +1,6 @@
 """An async vector environment."""
 import os
-from torch import multiprocessing as mp
+
 import sys
 from copy import deepcopy
 from enum import Enum
@@ -9,30 +9,13 @@ import pickle
 import io
 import contextlib
 import dgl
+from dgl import multiprocessing as mp
 import numpy as np
+import time
 
-# from numpy.typing import NDArray
 
 from psp.env.genv import GEnv as Env
 
-# import gymnasium as gym
-# from gymnasium.core import Env, ObsType
-# from gymnasium.error import (
-#     AlreadyPendingCallError,
-#     ClosedEnvironmentError,
-#     CustomSpaceError,
-#     NoAsyncCallError,
-# )
-# from gymnasium.vector.utils import (
-#     CloudpickleWrapper,
-#     clear_mpi_env_vars,
-#     concatenate,
-#     create_empty_array,
-#     create_shared_memory,
-#     iterate,
-#     read_from_shared_memory,
-#     write_to_shared_memory,
-# )
 from .vector_env import GraphVectorEnv
 
 __all__ = ["AsyncVectorEnv"]
@@ -43,32 +26,6 @@ class AsyncState(Enum):
     WAITING_RESET = "reset"
     WAITING_STEP = "step"
     WAITING_CALL = "call"
-
-
-@contextlib.contextmanager
-def clear_mpi_env_vars():
-    """Clears the MPI of environment variables.
-
-    `from mpi4py import MPI` will call `MPI_Init` by default.
-    If the child process has MPI environment variables, MPI will think that the child process
-    is an MPI process just like the parent and do bad things such as hang.
-
-    This context manager is a hacky way to clear those environment variables
-    temporarily such as when we are starting multiprocessing Processes.
-
-    Yields:
-        Yields for the context manager
-    """
-    removed_environment = {}
-    for k, v in list(os.environ.items()):
-        for prefix in ["OMPI_", "PMI_"]:
-            if k.startswith(prefix):
-                removed_environment[k] = v
-                del os.environ[k]
-    try:
-        yield
-    finally:
-        os.environ.update(removed_environment)
 
 
 class CloudpickleWrapper:
@@ -110,8 +67,6 @@ def create_shared_memory(size, n, ctx, disk):
 
 
 def read_from_shared_memory(shared_memory, n, disk):
-    # TODO return shared_mem[n]
-    # return [pickle.loads(shared_memory[i].get_obj()) for i in range(n)]
     if disk:
         return [dgl.load_graphs(shared_memory[i])[0][0] for i in range(n)]
     else:
@@ -152,36 +107,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         worker: Optional[Callable] = None,
         disk=True,
     ):
-        """Vectorized environment that runs multiple environments in parallel.
-
-        Args:
-            env_fns: Functions that create the environments.
-            observation_space: Observation space of a single environment. If ``None``,
-                then the observation space of the first environment is taken.
-            action_space: Action space of a single environment. If ``None``,
-                then the action space of the first environment is taken.
-            shared_memory: If ``True``, then the observations from the worker processes are communicated back through
-                shared variables. This can improve the efficiency if the observations are large (e.g. images).
-            copy: If ``True``, then the :meth:`~AsyncVectorEnv.reset` and :meth:`~AsyncVectorEnv.step` methods
-                return a copy of the observations.
-            context: Context for `multiprocessing`_. If ``None``, then the default context is used.
-            daemon: If ``True``, then subprocesses have ``daemon`` flag turned on; that is, they will quit if
-                the head process quits. However, ``daemon=True`` prevents subprocesses to spawn children,
-                so for some environments you may want to have it set to ``False``.
-            worker: If set, then use that worker in a subprocess instead of a default one.
-                Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
-
-        Warnings:
-            worker is an advanced mode option. It provides a high degree of flexibility and a high chance
-            to shoot yourself in the foot; thus, if you are writing your own worker, it is recommended to start
-            from the code for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.
-
-        Raises:
-            RuntimeError: If the observation space of some sub-environment does not match observation_space
-                (or, by default, the observation space of the first sub-environment).
-            ValueError: If observation_space is a custom space (i.e. not a default space in Gym,
-                such as gymnasium.spaces.Box, gymnasium.spaces.Discrete, or gymnasium.spaces.Dict) and shared_memory is True.
-        """
         ctx = mp.get_context(context)
         self.env_fns = env_fns
         self.shared_memory = shared_memory
@@ -198,43 +123,36 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
             self._obs_buffer = create_shared_memory(
                 2000000, n=self.num_envs, ctx=ctx, disk=self.disk
             )
-            # self.observations = read_from_shared_memory(
-            #     self.single_observation_space, _obs_buffer, n=self.num_envs
-            # )
         else:
             _obs_buffer = None
-            # self.observations = create_empty_array(
-            #     self.single_observation_space, n=self.num_envs, fn=np.zeros
-            # )
         self.observations = []
 
         self.parent_pipes, self.processes = [], []
         self.error_queue = ctx.Queue()
         target = _worker_shared_memory if self.shared_memory else _worker
         target = worker or target
-        with clear_mpi_env_vars():
-            for idx, env_fn in enumerate(self.env_fns):
-                parent_pipe, child_pipe = ctx.Pipe()
-                process = ctx.Process(
-                    target=target,
-                    name=f"Worker<{type(self).__name__}>-{idx}",
-                    args=(
-                        idx,
-                        CloudpickleWrapper(env_fn),
-                        child_pipe,
-                        parent_pipe,
-                        self._obs_buffer,
-                        self.disk,
-                        self.error_queue,
-                    ),
-                )
+        for idx, env_fn in enumerate(self.env_fns):
+            parent_pipe, child_pipe = ctx.Pipe()
+            process = ctx.Process(
+                target=target,
+                name=f"Worker<{type(self).__name__}>-{idx}",
+                args=(
+                    idx,
+                    CloudpickleWrapper(env_fn),
+                    child_pipe,
+                    parent_pipe,
+                    self._obs_buffer,
+                    self.disk,
+                    self.error_queue,
+                ),
+            )
 
-                self.parent_pipes.append(parent_pipe)
-                self.processes.append(process)
+            self.parent_pipes.append(parent_pipe)
+            self.processes.append(process)
 
-                process.daemon = daemon
-                process.start()
-                child_pipe.close()
+            process.daemon = daemon
+            process.start()
+            child_pipe.close()
 
         self._state = AsyncState.DEFAULT
 
@@ -243,20 +161,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         seed: Optional[Union[int, List[int]]] = None,
         options: Optional[dict] = None,
     ):
-        """Send calls to the :obj:`reset` methods of the sub-environments.
-
-        To get the results of these calls, you may invoke :meth:`reset_wait`.
-
-        Args:
-            seed: List of seeds for each environment
-            options: The reset option
-
-        Raises:
-            ClosedEnvironmentError: If the environment was closed (if :meth:`close` was previously called).
-            AlreadyPendingCallError: If the environment is already waiting for a pending call to another
-                method (e.g. :meth:`step_async`). This can be caused by two consecutive
-                calls to :meth:`reset_async`, with no call to :meth:`reset_wait` in between.
-        """
         self._assert_is_running()
 
         if seed is None:
@@ -287,21 +191,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         seed: Optional[int] = None,
         options: Optional[dict] = None,
     ):
-        """Waits for the calls triggered by :meth:`reset_async` to finish and returns the results.
-
-        Args:
-            timeout: Number of seconds before the call to `reset_wait` times out. If `None`, the call to `reset_wait` never times out.
-            seed: ignored
-            options: ignored
-
-        Returns:
-            A tuple of batched observations and list of dictionaries
-
-        Raises:
-            ClosedEnvironmentError: If the environment was closed (if :meth:`close` was previously called).
-            NoAsyncCallError: If :meth:`reset_wait` was called without any prior call to :meth:`reset_async`.
-            TimeoutError: If :meth:`reset_wait` timed out.
-        """
         self._assert_is_running()
         if self._state != AsyncState.WAITING_RESET:
             raise NoAsyncCallError(
@@ -318,7 +207,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         observations_list, infos = [], {}
         successes = []
 
-        #        results, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
         for i, pipe in enumerate(self.parent_pipes):
             result, success = pipe.recv()
             successes.append(success)
@@ -331,15 +219,7 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         self._raise_if_errors(successes)
         self._state = AsyncState.DEFAULT
 
-        #        infos = {}
-        # results, info_data = zip(*results)
-        # for i, info in enumerate(info_data):
-        #     infos = self._add_info(infos, info, i)
-
         if not self.shared_memory:
-            # self.observations = concatenate(
-            #     self.single_observation_space, results, self.observations
-            # )
             self.observations = observations_list
         else:
             self.observations = read_from_shared_memory(
@@ -349,18 +229,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         return (deepcopy(self.observations) if self.copy else self.observations), infos
 
     def step_async(self, actions):
-        """Send the calls to :obj:`step` to each sub-environment.
-
-        Args:
-            actions: Batch of actions. element of :attr:`~VectorEnv.action_space`
-
-        Raises:
-            ClosedEnvironmentError: If the environment was closed (if :meth:`close` was previously called).
-            AlreadyPendingCallError: If the environment is already waiting for a pending call to another
-                method (e.g. :meth:`reset_async`). This can be caused by two consecutive
-                calls to :meth:`step_async`, with no call to :meth:`step_wait` in
-                between.
-        """
         self._assert_is_running()
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
@@ -368,27 +236,11 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
                 self._state.value,
             )
 
-        # actions = iterate(self.action_space, actions)
-
-        # for pipe, action in zip(self.parent_pipes, actions):
         for n, pipe in enumerate(self.parent_pipes):
             pipe.send(("step", actions[n]))
         self._state = AsyncState.WAITING_STEP
 
     def step_wait(self, timeout: Optional[Union[int, float]] = None):
-        """Wait for the calls to :obj:`step` in each sub-environment to finish.
-
-        Args:
-            timeout: Number of seconds before the call to :meth:`step_wait` times out. If ``None``, the call to :meth:`step_wait` never times out.
-
-        Returns:
-             The batched environment step information, (obs, reward, terminated, truncated, info)
-
-        Raises:
-            ClosedEnvironmentError: If the environment was closed (if :meth:`close` was previously called).
-            NoAsyncCallError: If :meth:`step_wait` was called without any prior call to :meth:`step_async`.
-            TimeoutError: If :meth:`step_wait` timed out.
-        """
         self._assert_is_running()
         if self._state != AsyncState.WAITING_STEP:
             raise NoAsyncCallError(
@@ -435,17 +287,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         )
 
     def call_async(self, name: str, *args, **kwargs):
-        """Calls the method with name asynchronously and apply args and kwargs to the method.
-
-        Args:
-            name: Name of the method or property to call.
-            *args: Arguments to apply to the method call.
-            **kwargs: Keyword arguments to apply to the method call.
-
-        Raises:
-            ClosedEnvironmentError: If the environment was closed (if :meth:`close` was previously called).
-            AlreadyPendingCallError: Calling `call_async` while waiting for a pending call to complete
-        """
         self._assert_is_running()
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
@@ -459,19 +300,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         self._state = AsyncState.WAITING_CALL
 
     def call_wait(self, timeout: Optional[Union[int, float]] = None) -> list:
-        """Calls all parent pipes and waits for the results.
-
-        Args:
-            timeout: Number of seconds before the call to `step_wait` times out.
-                If `None` (default), the call to `step_wait` never times out.
-
-        Returns:
-            List of the results of the individual calls to the method or property for each environment.
-
-        Raises:
-            NoAsyncCallError: Calling `call_wait` without any prior call to `call_async`.
-            TimeoutError: The call to `call_wait` has timed out after timeout second(s).
-        """
         self._assert_is_running()
         if self._state != AsyncState.WAITING_CALL:
             raise NoAsyncCallError(
@@ -492,18 +320,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
         return results
 
     def set_attr(self, name: str, values: Union[list, tuple, object]):
-        """Sets an attribute of the sub-environments.
-
-        Args:
-            name: Name of the property to be set in each individual environment.
-            values: Values of the property to be set to. If ``values`` is a list or
-                tuple, then it corresponds to the values for each individual
-                environment, otherwise a single value is set for all environments.
-
-        Raises:
-            ValueError: Values must be a list or tuple with length equal to the number of environments.
-            AlreadyPendingCallError: Calling `set_attr` while waiting for a pending call to complete.
-        """
         self._assert_is_running()
         if not isinstance(values, (list, tuple)):
             values = [values for _ in range(self.num_envs)]
@@ -529,17 +345,6 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
     def close_extras(
         self, timeout: Optional[Union[int, float]] = None, terminate: bool = False
     ):
-        """Close the environments & clean up the extra resources (processes and pipes).
-
-        Args:
-            timeout: Number of seconds before the call to :meth:`close` times out. If ``None``,
-                the call to :meth:`close` never times out. If the call to :meth:`close`
-                times out, then all processes are terminated.
-            terminate: If ``True``, then the :meth:`close` operation is forced and all processes are terminated.
-
-        Raises:
-            TimeoutError: If :meth:`close` timed out.
-        """
         timeout = 0 if terminate else timeout
         try:
             if self._state != AsyncState.DEFAULT:

--- a/psp/env/graphgym/async_vector_env.py
+++ b/psp/env/graphgym/async_vector_env.py
@@ -119,7 +119,6 @@ def read_from_shared_memory(shared_memory, n, disk):
 
 
 def write_to_shared_memory(index, obs, shared_memory, disk):
-    # TODO : noop
     if disk:
         dgl.save_graphs(shared_memory[index], [obs])
     else:
@@ -413,7 +412,7 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
                 if not self.shared_memory:
                     observations_list.append(obs)
                 rewards.append(rew)
-                terminateds.append(terminated)
+                terminateds.append(terminated.item())
                 truncateds.append(truncated)
                 infos = self._add_info(infos, info, i)
 
@@ -611,6 +610,13 @@ class AsyncGraphVectorEnv(GraphVectorEnv):
 
     def __del__(self):
         """On deleting the object, checks that the vector environment is closed."""
+        if self.shared_memory and self.disk:
+            for b in self._obs_buffer:
+                try:
+                    os.remove(b)
+                except:
+                    pass
+
         if not getattr(self, "closed", True) and hasattr(self, "_state"):
             self.close(terminate=True)
 

--- a/psp/env/gstate.py
+++ b/psp/env/gstate.py
@@ -369,6 +369,9 @@ class GState:
     def resources_usage(self, node_id):
         return self.graph.ndata["resources"][node_id]
 
+    def all_resources_usage(self, node_id):
+        return self.graph.ndata["resources"]
+
     def resource_usage(self, node_id, r):
         return self.graph.ndata["resources"][node_id][r]
 
@@ -410,6 +413,17 @@ class GState:
 
     def all_not_affected(self):
         return self.graph.ndata["affected"] == 0
+
+    def trivial_actions(self):
+        return torch.where(
+            torch.logical_and(
+                self.selectables() == 1,
+                torch.all(self.all_resources_usage() == 0, 1),
+            )
+        )[0]
+
+    def unmasked_actions(self):
+        return torch.where(self.selectables() == 1)[0]
 
     ############################### EXTERNAL API ############################
 

--- a/psp/env/gstate.py
+++ b/psp/env/gstate.py
@@ -28,9 +28,12 @@ class GState:
         observe_conflicts_as_cliques=True,
         normalize_features=True,
     ):
+        # self.tpe = ThreadPoolExecutor()
         self.problem = problem
         self.problem_description = problem_description
         self.n_features = env_specification.n_features
+        # self.device = torch.device("cuda:2")
+        self.device = torch.device("cpu")
         if isinstance(self.problem, dict):
             self.n_nodes = self.problem["n_modes"]
         else:
@@ -157,10 +160,17 @@ class GState:
             ("n", "rnodeconf", "n"): ((), ()),
         }
 
-        self.graph = dgl.heterograph(gd)
-        self.graph.ndata["job"] = torch.zeros(self.n_nodes, dtype=torch.int)
+        self.graph = dgl.heterograph(gd, device=self.device)
+
+        self.pred_cache = {}
+        for n in range(self.graph.num_nodes()):
+            self.pred_cache[n] = self.graph.predecessors(n, etype="prec")
+
+        self.graph.ndata["job"] = torch.zeros(
+            self.n_nodes, dtype=torch.int, device=self.device
+        )
         self.graph.ndata["durations"] = torch.zeros(
-            (self.n_nodes, 3), dtype=torch.float
+            (self.n_nodes, 3), dtype=torch.float, device=self.device
         )
 
         m = 0
@@ -183,13 +193,17 @@ class GState:
                     item for sublist in self.problem["durations"][i] for item in sublist
                 ]
                 # self.features[:, 4 + i] = np.array(flat_dur)
-                self.graph.ndata["durations"][:, i] = torch.tensor(flat_dur)
+                self.graph.ndata["durations"][:, i] = torch.tensor(flat_dur).to(
+                    self.device
+                )
         else:
             for i in range(3):
                 flat_dur = [
                     item for sublist in self.problem.durations[i] for item in sublist
                 ]
-                self.graph.ndata["durations"][:, i] = torch.tensor(flat_dur)
+                self.graph.ndata["durations"][:, i] = torch.tensor(flat_dur).to(
+                    self.device
+                )
 
         if redraw_real:
             # self.real_durations = self.draw_real_durations(self.features[:, 4:7])
@@ -207,7 +221,12 @@ class GState:
         self.undoable_makespan = self.duration_upper_bound + self.max_duration
 
     def reset_is_affected(self):
-        self.graph.ndata["affected"] = torch.zeros((self.n_nodes), dtype=torch.float)
+        self.graph.ndata["affected"] = torch.zeros(
+            (self.n_nodes), dtype=torch.float, device=self.device
+        )
+        self.graph.ndata["past"] = torch.zeros(
+            (self.n_nodes), dtype=torch.bool, device=self.device
+        )
 
     def reset(self):
         self.reset_graph()
@@ -274,7 +293,7 @@ class GState:
         else:
             self.n_resources = self.problem.n_resources
             self.graph.ndata["resources"] = torch.zeros(
-                (self.n_nodes, self.n_resources), dtype=torch.float
+                (self.n_nodes, self.n_resources), dtype=torch.float, device=self.device
             )
             flat_res = torch.tensor(
                 [item for sublist in self.problem.resource_cons for item in sublist],
@@ -283,7 +302,9 @@ class GState:
             # normalize resource usage
             for i in range(self.problem.n_resources):
                 flat_res[:, i] /= self.problem.resource_availabilities[i]
-            self.resource_levels = torch.tensor(self.problem.resource_availabilities)
+            self.resource_levels = torch.tensor(
+                self.problem.resource_availabilities
+            ).to(self.device)
 
             # self.features[:, 10 : 10 + self.n_resources] = flat_res
             self.graph.ndata["resources"][:] = flat_res
@@ -329,18 +350,25 @@ class GState:
 
     def reset_selectable(self):
         self.graph.ndata["selectable"] = torch.where(
-            self.graph.in_degrees(etype="prec") == 0, 1.0, 0.0
+            self.graph.in_degrees(etype="prec") == 0, True, False
         )  # source
 
     def reset_tct(self):
-        self.real_tct = torch.zeros((self.n_nodes), dtype=torch.float)
-        self.graph.ndata["tct"] = torch.zeros((self.n_nodes, 3), dtype=torch.float)
+        self.real_tct = torch.zeros(
+            (self.n_nodes), dtype=torch.float, device=self.device
+        )
+        self.graph.ndata["tct"] = torch.zeros(
+            (self.n_nodes, 3), dtype=torch.float, device=self.device
+        )
         self.update_completion_times(None)
 
     ############################### ACCESSORS ############################
 
     def tct(self, nodeid):
         return self.graph.ndata["tct"][nodeid]
+
+    def all_tct(self):
+        return self.graph.ndata["tct"]
 
     def all_tct_real(self):
         return self.real_tct
@@ -369,7 +397,7 @@ class GState:
     def resources_usage(self, node_id):
         return self.graph.ndata["resources"][node_id]
 
-    def all_resources_usage(self, node_id):
+    def all_resources_usage(self):
         return self.graph.ndata["resources"]
 
     def resource_usage(self, node_id, r):
@@ -385,13 +413,13 @@ class GState:
         return self.graph.ndata["type"]
 
     def selectable(self, node_id):
-        return self.graph.ndata["selectable"][node_id] == 1
+        return self.graph.ndata["selectable"][node_id]
 
     def set_unselectable(self, node_id):
-        self.graph.ndata["selectable"][node_id] = 0
+        self.graph.ndata["selectable"][node_id] = False
 
     def set_selectable(self, node_id):
-        self.graph.ndata["selectable"][node_id] = 1
+        self.graph.ndata["selectable"][node_id] = True
 
     def jobid(self, node_id):
         return self.graph.ndata["job"][node_id]
@@ -414,16 +442,22 @@ class GState:
     def all_not_affected(self):
         return self.graph.ndata["affected"] == 0
 
+    def set_past(self, nodeid):
+        self.graph.ndata["past"][nodeid] = True
+
+    def get_pasts(self):
+        return self.graph.ndata["past"]
+
     def trivial_actions(self):
         return torch.where(
             torch.logical_and(
-                self.selectables() == 1,
+                self.selectables(),
                 torch.all(self.all_resources_usage() == 0, 1),
             )
         )[0]
 
     def unmasked_actions(self):
-        return torch.where(self.selectables() == 1)[0]
+        return self.selectables().to(torch.device("cpu")).numpy()
 
     ############################### EXTERNAL API ############################
 
@@ -431,7 +465,8 @@ class GState:
         return self.finished() or self.succeeded()
 
     def finished(self):
-        return torch.where(self.selectables() == 1)[0].size()[0] == 0
+        # return torch.where(self.selectables())[0].size()[0] == 0
+        return torch.all(torch.logical_not(self.selectables()))
 
     def succeeded(self):
         sinks = torch.where(self.types() == 1)[0]
@@ -443,62 +478,6 @@ class GState:
     def observe(self):
         self.normalize_features()
         return self.graph
-
-    # def to_features_and_edge_index(self, normalize):
-    #     if self.observe_conflicts_as_cliques:
-    #         rce = self.resource_conf_edges
-    #         rca = np.stack(
-    #             [
-    #                 self.resource_conf_id,
-    #                 self.resource_conf_val,
-    #                 self.resource_conf_val_r,
-    #             ],
-    #             axis=1,
-    #         )
-    #     else:
-    #         rce = None
-    #         rca = None
-
-    #     if self.add_rp_edges != "none":
-    #         if len(self.resource_prec_edges) > 0:
-    #             if self.add_rp_edges == "all":
-    #                 rpe = np.transpose(self.resource_prec_edges)
-    #                 rpa = np.concatenate(self.resource_prec_att)
-    #             elif self.add_rp_edges == "frontier":
-    #                 rpe, rpa = self.rp_edges_to_keep()
-    #             elif self.add_rp_edges == "frontier_strict":
-    #                 rpe, rpa = self.rp_edges_to_keep_strict()
-    #             else:
-    #                 raise NotImplementedError
-    #         else:
-    #             rpe = None
-    #             rpa = None
-    #         return (
-    #             self.normalize_features(),
-    #             self.numpy_problem_graph,
-    #             rce,
-    #             rca,
-    #             rpe,
-    #             rpa,
-    #         )
-
-    #     if self.remove_past_prec:
-    #         fresh_nodes = list(
-    #             set(np.where(self.all_not_affected())[0]).union(self.nodes_in_frontier)
-    #         )
-
-    #         return (
-    #             self.normalize_features(),
-    #             self.remove_past_edges(fresh_nodes),
-    #             rce,
-    #             rca,
-    #         )
-    #     return (
-    #         self.normalize_features(),
-    #         self.numpy_problem_graph,
-    #         rce,
-    #         rca,
-    #     )
 
     def affect_job(self, node_id):
         self.affect_node(node_id)
@@ -521,7 +500,8 @@ class GState:
             self.remove_past_edges(nodes_removed_from_frontier, node_id)
 
     def mask_wrt_non_renewable_resources(self):
-        selectables = torch.where(self.graph.ndata["selectable"] == 1)[0]
+        # selectables = torch.where(self.graph.ndata["selectable"] == 1)[0]
+        selectables = torch.where(self.selectables())[0]
         for n in selectables:
             for r, level in enumerate(self.resources_usage(n)):
                 if not self.resources[r][0].still_available(level):
@@ -638,11 +618,11 @@ class GState:
         schedule = tct - self.real_durations[:]
 
         return Solution.from_mode_schedule(
-            schedule,
+            schedule.to(torch.device("cpu")),
             self.problem,
-            self.all_affected(),
-            self.all_jobid(),
-            real_durations=self.real_durations,
+            self.all_affected().to(torch.device("cpu")),
+            self.all_jobid().to(torch.device("cpu")),
+            real_durations=self.real_durations.to(torch.device("cpu")),
         )
 
     ############################ INTERNAL ###############################
@@ -653,6 +633,7 @@ class GState:
             nodeid
         ), f"invalid action selected:  {nodeid} ; selectables: {self.selectables() == 1}"
         # all modes become unselectable
+        self.set_past(self.modes(self.jobid(nodeid).item()))
         self.set_unselectable(self.modes(self.jobid(nodeid).item()))
         if self.remove_old_resource_info:
             other_modes = self.modes(self.jobid(nodeid)).copy()
@@ -694,16 +675,17 @@ class GState:
 
     def get_last_finishing_dates(self, jobs):
         if len(jobs) == 0:
-            return torch.zeros((3), dtype=torch.float)
+            return torch.zeros((3), dtype=torch.float, device=self.device)
         return torch.amax(self.tct(jobs), axis=0)
 
     def get_last_finishing_dates_real(self, jobs):
         if len(jobs) == 0:
-            return torch.tensor([0.0])
+            return torch.tensor([0.0], device=self.device)
         return torch.amax(self.tct_real(jobs), 0, keepdim=True)
 
     def compute_dates_on_affectation(self, node_id):
-        job_parents = self.graph.predecessors(node_id, etype="prec")
+        # job_parents = self.graph.predecessors(node_id, etype="prec")
+        job_parents = self.cached_pred(node_id)
         affected_parents = job_parents[torch.where(self.affected(job_parents))[0]]
         last_parent_finish_date = self.get_last_finishing_dates(affected_parents)
         last_parent_finish_date_real = self.get_last_finishing_dates_real(
@@ -711,7 +693,9 @@ class GState:
         )
 
         resources_used = torch.where(self.resources_usage(node_id) != 0)[0]
-        max_r_date = torch.tensor([0.0, 0.0, 0.0, 0.0], dtype=torch.float)
+        max_r_date = torch.tensor(
+            [0.0, 0.0, 0.0, 0.0], dtype=torch.float, device=self.device
+        )
         constraining_resource = [None] * 4
 
         for r in resources_used:
@@ -765,7 +749,11 @@ class GState:
             for r in range(self.n_resources):
                 for i in range(3):
                     if self.resources[r][i + 1].new_edges_cache:
-                        ne = torch.tensor(self.resources[r][i + 1].new_edges_cache).t()
+                        ne = (
+                            torch.tensor(self.resources[r][i + 1].new_edges_cache)
+                            .t()
+                            .to(self.device)
+                        )
                         rpa = torch.empty(
                             (len(self.resources[r][i + 1].new_edges_cache), 4),
                             dtype=torch.float,
@@ -806,32 +794,57 @@ class GState:
             self.tct(self.graph.predecessors(cur_node_id, etype="prec")), 0, True
         )
 
-    def update_completion_times(self, node_id):
-        self.tpe = ThreadPoolExecutor(max_workers=1)
+    def cached_pred(self, node_id):
+        return self.pred_cache[node_id]
+        # if node_id in self.pred_cache.keys():
+        #     return self.pred_cache[node_id]
+        # preds = self.graph.predecessors(node_id, etype="prec")
+        # self.pred_cache[node_id] = preds
+        # return preds
 
+    def update_completion_times(self, node_id):
+        initial_tct = False
         if node_id is None:
             indeg = self.graph.in_degrees(etype="prec")
             open_nodes = torch.where(indeg == 0)[0].tolist()
+            initial_tct = True
         else:
             open_nodes = [node_id.item()]
         while open_nodes:
             cur_node_id = open_nodes.pop(0)
 
             if self.graph.in_degrees(cur_node_id, etype="prec") == 0:
-                max_tct_predecessors = torch.zeros((3), dtype=torch.float)
-                max_tct_predecessors_real = torch.zeros((1), dtype=torch.float)
+                max_tct_predecessors = torch.zeros(
+                    (3), dtype=torch.float, device=self.device
+                )
+                max_tct_predecessors_real = torch.zeros(
+                    (1), dtype=torch.float, device=self.device
+                )
             else:
                 # max_tct_predecessors = torch.max(
                 #     self.tct(self.graph.predecessors(cur_node_id, etype="prec")),
                 #     0,
                 #     keepdim=True,
                 # )[0]
-                max_tct_predecessors = self.tpe.submit(
-                    self.max_thread_safe, cur_node_id
-                ).result()[0]
-                max_tct_predecessors_real = torch.max(
-                    self.tct_real(self.graph.predecessors(cur_node_id, etype="prec"))
-                )
+                # max_tct_predecessors = self.tpe.submit(
+                #     self.max_thread_safe, cur_node_id
+                # ).result()[0]
+                # preds = self.graph.predecessors(cur_node_id, etype="prec")
+                preds = self.cached_pred(cur_node_id)
+                max_tct_predecessors = torch.from_numpy(
+                    np.max(
+                        self.tct(preds).to(torch.device("cpu")).numpy(),
+                        axis=0,
+                        keepdims=True,
+                    )
+                ).to(self.device)
+
+                # max_tct_predecessors_real = torch.max(
+                #     self.tct_real(self.graph.predecessors(cur_node_id, etype="prec"))
+                # )
+                max_tct_predecessors_real = torch.tensor(
+                    np.max(self.tct_real(preds).to(torch.device("cpu")).numpy())
+                ).to(self.device)
 
             new_completion_time = max_tct_predecessors + self.durations(cur_node_id)
             new_completion_time_real = max_tct_predecessors_real + self.duration_real(
@@ -839,17 +852,26 @@ class GState:
             )
 
             if (
-                torch.not_equal(new_completion_time_real, self.tct_real(cur_node_id))
-            ) or (
-                torch.any(torch.not_equal(new_completion_time, self.tct(cur_node_id)))
+                initial_tct
+                or (
+                    torch.not_equal(
+                        new_completion_time_real, self.tct_real(cur_node_id)
+                    )
+                )
+                or (
+                    torch.any(
+                        torch.not_equal(new_completion_time, self.tct(cur_node_id))
+                    )
+                )
             ):
                 self.set_tct(cur_node_id, new_completion_time)
                 self.set_tct_real(cur_node_id, new_completion_time_real)
 
                 for successor in self.graph.successors(cur_node_id, etype="prec"):
                     to_open = True
-                    for p in self.graph.predecessors(successor, etype="prec"):
-                        if p.item() in open_nodes:
+                    # for p in self.graph.predecessors(successor, etype="prec"):
+                    for p in self.cached_pred(successor.item()):
+                        if p.item() == cur_node_id or p.item() in open_nodes:
                             to_open = False
                             break
                     if to_open:

--- a/psp/env/state.py
+++ b/psp/env/state.py
@@ -503,9 +503,20 @@ class State:
                         self.nodes_in_frontier.add(fe[1])
 
     def mask_wrt_non_renewable_resources(self):
+        if isinstance(self.problem, dict):
+            if self.problem["n_nonrenewable_resources"] == 0:
+                return
+        else:
+            if self.problem.n_nonrenewable_resources == 0:
+                return
         selectables = np.where(self.features[:, 1] == 1)[0]
+        # TODO rewrite
         for n in selectables:
-            for r, level in enumerate(self.resources_usage(n)):
+            for r, level in enumerate(
+                self.resources_usage(n)[self.problem["n_renewable_resources"], :]
+            ):
+                if level == 0:
+                    continue
                 if not self.resources[r][0].still_available(level):
                     self.set_unselectable(n)
                     break

--- a/psp/env/state.py
+++ b/psp/env/state.py
@@ -50,6 +50,9 @@ class State:
         self.add_rp_edges = env_specification.add_rp_edges
         self.factored_rp = env_specification.factored_rp
 
+        self.step_horizon = env_specification.observation_horizon_step
+        self.time_horizon = env_specification.observation_horizon_time
+
         self.edge_index = {}
 
         self.resource_prec_edges = []
@@ -104,6 +107,7 @@ class State:
         else:
             self.problem_graph.add_nodes_from(range(0, problem.n_modes))
         self.problem_graph.add_edges_from(self.problem_edges)
+
         # nx.draw_networkx(self.graph)
         # plt.show()
         self.numpy_problem_graph = np.transpose(np.array(self.problem_edges))
@@ -307,6 +311,12 @@ class State:
         no_child = out_deg[no_child_pos][:, 0]
         self.features[no_child, 3] = 1  # sink
 
+    def get_weight(self, source, dest, edge_attr):
+        if source >= self.features.shape[0]:
+            # case of virtual added source
+            return 0
+        return self.features[source, 4]
+
     def reset_selectable(self):
         self.features[:, 1] = 0
         in_deg = np.array(self.problem_graph.in_degree())
@@ -351,6 +361,9 @@ class State:
     def resources_usage(self, node_id):
         return self.features[node_id, 10:]
 
+    def all_resources_usage(self):
+        return self.features[:, 10:]
+
     def resource_usage(self, node_id, r):
         return self.features[node_id, 10 + r]
 
@@ -392,6 +405,16 @@ class State:
 
     def all_not_affected(self):
         return self.features[:, 0] == 0
+
+    def trivial_actions(self):
+        return np.where(
+            np.logical_and(
+                self.selectables() == 1, np.all(self.all_resources_usage() == 0, axis=1)
+            )
+        )[0]
+
+    def unmasked_actions(self):
+        return np.where(self.selectables() == 1)[0]
 
     ############################### EXTERNAL API ############################
 
@@ -439,7 +462,7 @@ class State:
                 rpe = None
                 rpa = None
             return (
-                self.normalize_features(),
+                self.process_features(),
                 self.numpy_problem_graph,
                 rce,
                 rca,
@@ -453,13 +476,13 @@ class State:
             )
 
             return (
-                self.normalize_features(),
+                self.process_features(),
                 self.remove_past_edges(fresh_nodes),
                 rce,
                 rca,
             )
         return (
-            self.normalize_features(),
+            self.process_features(),
             self.numpy_problem_graph,
             rce,
             rca,
@@ -640,12 +663,45 @@ class State:
                 # make selectable, at last
                 self.set_selectable(successor)
 
-    def normalize_features(self):
-        if self.normalize:
+    def process_features(self):
+        if self.normalize or self.step_horizon != 0 or self.time_horizon != 0:
             feat = np.copy(self.features)
+        else:
+            feat = self.features
+        if self.normalize:
             feat[:, 4:10] /= self.max_duration
-            return feat
-        return self.features
+        if self.step_horizon != 0 or self.time_horizon != 0:
+            # recompute reachable nodes in step_horizon steps in not_affected ones
+            sources = np.where(self.features[:, 1] == 1)[0]
+            v_source = self.problem_graph.number_of_nodes()
+            self.problem_graph.add_node(v_source)
+            for i in sources:
+                self.problem_graph.add_edge(v_source, i)
+            # not_affected = (np.where(self.features[:, 0] == 0)[0]).tolist()
+            to_remove = []
+            if self.step_horizon != 0:
+                step_depth = nx.shortest_path_length(
+                    self.problem_graph, source=v_source
+                )
+                for i in step_depth.keys():
+                    if i == v_source:
+                        continue
+                    if step_depth[i] > self.step_horizon:
+                        to_remove.append(i)
+            if self.time_horizon != 0:
+                time_depth = nx.shortest_path_length(
+                    self.problem_graph, source=v_source, weight=self.get_weight
+                )
+                for i in time_depth.keys():
+                    if i == v_source:
+                        continue
+                    if time_depth[i] > self.time_horizon:
+                        to_remove.append(i)
+
+            feat[to_remove, 10:] = 0
+            self.problem_graph.remove_node(v_source)
+
+        return feat
 
     def get_last_finishing_dates(self, jobs):
         if len(jobs) == 0:

--- a/psp/env/transition_models/transition_model.py
+++ b/psp/env/transition_models/transition_model.py
@@ -36,20 +36,22 @@ class TransitionModel:
         self.env_specification = env_specification
 
     def run(self, state, node_id):  # noqa
+        steps = 1
         state.affect_job(node_id)
         if self.env_specification.fast_forward:
             while True:
                 unmasked_action = state.unmasked_actions()
                 if unmasked_action.shape[0] == 1:
-                    print("fast forwarding only action", unmasked_action[0])
+                    steps += 1
                     state.affect_job(unmasked_action[0])
                     continue
                 trivial_actions = state.trivial_actions()
                 if trivial_actions.shape[0] > 0:
-                    print("fast trivial action", trivial_actions[0])
-                    state.affect_job(trivial_actions[0])
+                    steps += 1
+                    state.affect_job(trivial_actions[0].item())
                     continue
                 break
+        return steps
 
     def get_mask(self, state):
         return state.selectables() == 1

--- a/psp/env/transition_models/transition_model.py
+++ b/psp/env/transition_models/transition_model.py
@@ -37,6 +37,19 @@ class TransitionModel:
 
     def run(self, state, node_id):  # noqa
         state.affect_job(node_id)
+        if self.env_specification.fast_forward:
+            while True:
+                unmasked_action = state.unmasked_actions()
+                if unmasked_action.shape[0] == 1:
+                    print("fast forwarding only action", unmasked_action[0])
+                    state.affect_job(unmasked_action[0])
+                    continue
+                trivial_actions = state.trivial_actions()
+                if trivial_actions.shape[0] > 0:
+                    print("fast trivial action", trivial_actions[0])
+                    state.affect_job(trivial_actions[0])
+                    continue
+                break
 
     def get_mask(self, state):
         return state.selectables() == 1

--- a/psp/models/agent.py
+++ b/psp/models/agent.py
@@ -281,8 +281,12 @@ class Agent(Agent):
         return AgentObservation.rebatch_obs(obs)
 
     def _obs_as_tensor_add_batch_dim_graph(self, obs):
+        if self.env_specification.observe_subgraph:
+            cobs = obs
+        else:
+            cobs = copy.deepcopy(obs)
         return AgentGraphObservation.rewire_internal(
-            copy.deepcopy(obs),
+            cobs,
             conflicts=self.agent_specification.conflicts,
             bidir=True,
             compute_laplacian_pe=False,

--- a/psp/models/agent.py
+++ b/psp/models/agent.py
@@ -97,7 +97,8 @@ class Agent(Agent):
                 layer_pooling=agent_specification.layer_pooling,
                 factored_rp=env_specification.factored_rp,
                 add_rp_edges=env_specification.add_rp_edges,
-                add_self_loops=env_specification.remove_past_prec,
+                add_self_loops=env_specification.remove_past_prec
+                or env_specification.observe_subgraph,
                 vnode=agent_specification.vnode,
                 update_edge_features=agent_specification.update_edge_features,
                 update_edge_features_pe=agent_specification.update_edge_features_pe,

--- a/psp/train_psp.py
+++ b/psp/train_psp.py
@@ -146,6 +146,9 @@ def main(args, exp_name, path) -> float:
         factored_rp=(args.fe_type == "tokengt" or args.factored_rp),
         remove_old_resource_info=not args.use_old_resource_info,
         remove_past_prec=not args.keep_past_prec,
+        observation_horizon_step=args.observation_horizon_step,
+        observation_horizon_time=args.observation_horizon_time,
+        fast_forward=not args.no_fast_forward,
     )
     env_specification.print_self()
     if args.batch_size == 1 and not args.dont_normalize_advantage:

--- a/psp/train_psp.py
+++ b/psp/train_psp.py
@@ -132,6 +132,7 @@ def main(args, exp_name, path) -> float:
         observe_real_duration_when_affect = True
     else:
         observe_real_duration_when_affect = False
+
     env_specification = EnvSpecification(
         problems=problem_description,
         normalize_input=not args.dont_normalize_input,
@@ -144,11 +145,13 @@ def main(args, exp_name, path) -> float:
         observe_real_duration_when_affect=observe_real_duration_when_affect,
         do_not_observe_updated_bounds=args.do_not_observe_updated_bounds,
         factored_rp=(args.fe_type == "tokengt" or args.factored_rp),
-        remove_old_resource_info=not args.use_old_resource_info,
-        remove_past_prec=not args.keep_past_prec,
+        remove_old_resource_info=not args.use_old_resource_info
+        and not args.observe_subgraph,
+        remove_past_prec=not args.keep_past_prec and not args.observe_subgraph,
         observation_horizon_step=args.observation_horizon_step,
         observation_horizon_time=args.observation_horizon_time,
         fast_forward=not args.no_fast_forward,
+        observe_subgraph=args.observe_subgraph,
     )
     env_specification.print_self()
     if args.batch_size == 1 and not args.dont_normalize_advantage:

--- a/psp/utils/rcpsp.py
+++ b/psp/utils/rcpsp.py
@@ -18,6 +18,7 @@ class Rcpsp:
         n_nonrenewable_resources=0,
         n_doubly_constrained_resources=0,
         use_index_from_zero=False,
+        due_dates=None,
     ):
         # Number of jobs in the graph
         self.n_jobs = n_jobs
@@ -55,6 +56,7 @@ class Rcpsp:
         self.max_resource_consumption = 0
 
         self.use_index_from_zero = use_index_from_zero
+        self.due_dates = due_dates
 
         for j in range(n_jobs):
             for k in range(n_modes_per_job[j]):

--- a/tests/test_psp.py
+++ b/tests/test_psp.py
@@ -134,8 +134,13 @@ def instantiate_training_objects(
         observe_real_duration_when_affect=observe_real_duration_when_affect,
         do_not_observe_updated_bounds=args.do_not_observe_updated_bounds,
         factored_rp=(args.fe_type == "tokengt" or args.factored_rp),
-        remove_old_resource_info=not args.use_old_resource_info,
-        remove_past_prec=not args.keep_past_prec,
+        remove_old_resource_info=not args.use_old_resource_info
+        and not args.observe_subgraph,
+        remove_past_prec=not args.keep_past_prec and not args.observe_subgraph,
+        observation_horizon_step=args.observation_horizon_step,
+        observation_horizon_time=args.observation_horizon_time,
+        fast_forward=not args.no_fast_forward,
+        observe_subgraph=args.observe_subgraph,
     )
 
     if args.batch_size == 1 and not args.dont_normalize_advantage:
@@ -270,6 +275,10 @@ possible_args = {
     "train_dir": ["./instances/psp/test/"],
     "vecenv_type": ["subproc", "graphgym"],
     "return_based_scaling": [True, False],
+    "observe_subgraph": [True, False],
+    "no_fast_forward": [True, False],
+    "observation_horizon_step": [0, 5],
+    "observation_horizon_time": [0, 5],
 }
 
 # Duplicate each entry to match the maximum number of possibilities to try.


### PR DESCRIPTION
this PR adds observation horizon , subgraphs as obs for graphgym and fast forward of trivial/unique actions (ie donot call the gnn at all).

fast forward of trivial actions: 
enabled by default, disable with  --no-fast-forward

observation horizon example:
--observation_horizon_time 50 --observation_horizon_step 8

clean subgraphs as obs with graphgym (remove completely unused nodes wrt past/horizon):
--observe_subgraph 

