### PR TITLE
fix: skip advantage normalization if last minibatch size is 1

### DIFF
--- a/alg/ppo.py
+++ b/alg/ppo.py
@@ -444,7 +444,7 @@ class PPO:
                         approx_kl_divs_on_epoch.append(approx_kl.item())
 
                     mb_advantages = b_advantages[mb_inds].to(train_device)
-                    if self.norm_adv:
+                    if self.norm_adv and mb_advantages.shape[0] > 1:
                         mb_advantages = (mb_advantages - mb_advantages.mean()) / (
                             mb_advantages.std() + 1e-8
                         )


### PR DESCRIPTION
To reproduce the bug:
```
python3 -m jssp.train --n_j 2 --n_m 2 --n_steps_episode 4 --batch_size 3 --n_workers 1 --n_epochs 1 --skip_initial_eval
```
Last minibatch size is 1, so `mb_advantages.std()` is nan and a nan loss is backpropagated.
Evaluation is stuck because the agent returns invalid actions.

SB3 has a similar workaround: https://github.com/DLR-RM/stable-baselines3/blob/c8fda060d4bcb283eea6ddd385be5a46a54d3356/stable_baselines3/ppo/ppo.py#L222