### PR TITLE
Dispatching rules: handle missing tasks and floating-points durations

### DIFF
--- a/jssp/dispatching_rules/test_dispatch_rules.py
+++ b/jssp/dispatching_rules/test_dispatch_rules.py
@@ -4,16 +4,12 @@ import numpy as np
 import pytest
 
 from instances.generate_taillard import generate_taillard
-from jssp.dispatching_rules.solver import (
-    Solver,
-    _occupancy,
-    missing_tasks_to_fictive,
-    reschedule,
-)
+from jssp.dispatching_rules.solver import Solver, _occupancy, reschedule
 from jssp.dispatching_rules.validate import (
     validate_job_tasks,
     validate_machine_tasks,
     validate_solution,
+    validate_solution_with_missing_tasks,
 )
 
 
@@ -116,9 +112,43 @@ def test_missing_tasks(
     ignore_unfinished_precedences: bool,
     expected_schedule: np.ndarray,
 ):
+    n_machines = affectations.shape[1]
+    durations[affectations == -1] = 0
+    affectations[affectations == -1] = n_machines
     solver = Solver(durations, affectations, heuristic, ignore_unfinished_precedences)
     schedule = solver.solve()
     assert np.allclose(schedule, expected_schedule)
+
+
+@pytest.mark.parametrize(
+    "schedule,real_durations,affectations,expected_schedule",
+    [
+        (
+            np.array([[0, 12, 12], [0, 12, 25]]),
+            np.array([[13, -1, 11], [4, 11, -1]]),
+            np.array([[1, -1, 2], [0, 1, -1]]),
+            np.array([[0, 13, 13], [0, 13, 24]]),
+        ),
+        (
+            np.array([[0, 12, 12], [0, 5, 18]]),
+            np.array([[10, -1, 17], [11, 13, -1]]),
+            np.array([[2, -1, 0], [0, 1, -1]]),
+            np.array([[0, 10, 11], [0, 11, 24]]),
+        ),
+    ],
+)
+def test_reschedule_missing_tasks(
+    schedule: np.ndarray,
+    real_durations: np.ndarray,
+    affectations: np.ndarray,
+    expected_schedule: np.ndarray,
+):
+    n_machines = affectations.shape[1]
+    real_durations[affectations == -1] = 0
+    affectations[affectations == -1] = n_machines
+    new_schedule = reschedule(real_durations, affectations, schedule)
+    validate_solution_with_missing_tasks(real_durations, affectations, new_schedule)
+    assert np.allclose(new_schedule, expected_schedule)
 
 
 @pytest.mark.parametrize(
@@ -200,9 +230,12 @@ def test_reschedule(n_jobs: int, n_machines: int, seed: int):
     new_schedule = reschedule(new_durations, affectations, schedule)
 
     validate_solution(new_durations, affectations, new_schedule)
-    assert np.all(
-        _occupancy(affectations, schedule) == _occupancy(affectations, new_schedule)
-    ), "The new schedule have swapped machine-tasks priorities"
+    occupancy_1 = _occupancy(affectations, schedule)
+    occupancy_2 = _occupancy(affectations, new_schedule)
+    for machine_id in range(len(occupancy_1)):
+        assert np.all(
+            occupancy_1[machine_id] == occupancy_2[machine_id]
+        ), "The new schedule have swapped machine-tasks priorities"
 
 
 @pytest.mark.parametrize(

--- a/jssp/dispatching_rules/validate.py
+++ b/jssp/dispatching_rules/validate.py
@@ -7,6 +7,7 @@ def validate_solution(
     affectations: np.ndarray,
     schedule: np.ndarray,
 ):
+    # TODO: Missing tasks
     # Make sure the given args are valids.
     validate_instance(durations, affectations)
     assert schedule.shape == durations.shape, "Wrong starting_times shape"
@@ -38,11 +39,11 @@ def validate_job_tasks(
 
     ending_times = schedule + durations
     previous_ending_times = np.concatenate(
-        (np.zeros((n_jobs, 1), dtype=np.int32), ending_times[:, :-1]),
+        (np.zeros((n_jobs, 1), dtype=durations.dtype), ending_times[:, :-1]),
         axis=1,
     )
     assert np.all(
-        previous_ending_times <= schedule
+        schedule - previous_ending_times >= -1e-5
     ), "Some tasks starts before their precedence (job-wise) is finished"
 
 
@@ -66,9 +67,11 @@ def validate_machine_tasks(
 
     ending_times = schedule + durations
     previous_ending_times = np.concatenate(
-        (np.zeros((n_machines, 1), dtype=np.int32), ending_times[:, :-1]),
+        (np.zeros((n_machines, 1), dtype=durations.dtype), ending_times[:, :-1]),
         axis=1,
     )
+    a = previous_ending_times - schedule
+    # print(a[a > 0])
     assert np.all(
-        previous_ending_times <= schedule
+        schedule - previous_ending_times >= -1e-5
     ), "Some tasks starts before their precedence (machine-wise) is finished"

--- a/jssp/dispatching_rules/validate.py
+++ b/jssp/dispatching_rules/validate.py
@@ -7,7 +7,6 @@ def validate_solution(
     affectations: np.ndarray,
     schedule: np.ndarray,
 ):
-    # TODO: Missing tasks
     # Make sure the given args are valids.
     validate_instance(durations, affectations)
     assert schedule.shape == durations.shape, "Wrong starting_times shape"
@@ -54,24 +53,48 @@ def validate_machine_tasks(
 ):
     _, n_machines = durations.shape
 
-    sort_by_machines = np.argsort(affectations, axis=1)
-    durations = np.take_along_axis(durations, sort_by_machines, axis=1)
-    schedule = np.take_along_axis(schedule, sort_by_machines, axis=1)
+    for machine_id in range(n_machines):
+        if not np.any(affectations == machine_id):
+            continue
 
-    durations = durations.transpose()
-    schedule = schedule.transpose()
+        schedule_machine = schedule[affectations == machine_id]
+        durations_machine = durations[affectations == machine_id]
 
-    sort_by_starting_times = np.argsort(schedule, axis=1)
-    schedule = np.take_along_axis(schedule, sort_by_starting_times, axis=1)
-    durations = np.take_along_axis(durations, sort_by_starting_times, axis=1)
+        sort_by_starting_times = np.argsort(schedule_machine)
+        schedule_machine = schedule_machine[sort_by_starting_times]
+        durations_machine = durations_machine[sort_by_starting_times]
 
-    ending_times = schedule + durations
-    previous_ending_times = np.concatenate(
-        (np.zeros((n_machines, 1), dtype=durations.dtype), ending_times[:, :-1]),
-        axis=1,
-    )
-    a = previous_ending_times - schedule
-    # print(a[a > 0])
-    assert np.all(
-        schedule - previous_ending_times >= -1e-5
-    ), "Some tasks starts before their precedence (machine-wise) is finished"
+        ending_times = schedule_machine + durations_machine
+        previous_ending_times = ending_times.copy()
+        previous_ending_times[1:] = ending_times[:-1]
+        previous_ending_times[0] = 0
+
+        assert np.all(
+            schedule_machine - previous_ending_times >= -1e-5
+        ), "Some tasks starts before their precedence (machine-wise) is finished"
+
+
+def validate_solution_with_missing_tasks(
+    durations: np.ndarray,
+    affectations: np.ndarray,
+    schedule: np.ndarray,
+):
+    # Make sure the given args are valids.
+    validate_instance_with_fictive_tasks(durations, affectations)
+    assert schedule.shape == durations.shape, "Wrong starting_times shape"
+
+    # Validate the solution.
+    assert np.all(schedule != -1), "Not all tasks have been started!"
+    validate_job_tasks(durations, affectations, schedule)
+    validate_machine_tasks(durations, affectations, schedule)
+
+
+def validate_instance_with_fictive_tasks(
+    durations: np.ndarray,
+    affectations: np.ndarray,
+):
+    n_machines = durations.shape[1]
+    assert durations.shape == affectations.shape, "Wrong number of jobs or machines"
+    assert (
+        affectations.min() == 0 and affectations.max() == n_machines
+    ), f"The indices must be in the range [0, n_machines] (found [{affectations.min()}, {affectations.max()}])"

--- a/jssp/dispatching_rules/validate.py
+++ b/jssp/dispatching_rules/validate.py
@@ -22,7 +22,7 @@ def validate_instance(durations: np.ndarray, affectations: np.ndarray):
     assert durations.shape == affectations.shape, "Wrong number of jobs or machines"
     assert (
         affectations.min() == 0 and affectations.max() == n_machines - 1
-    ), "The indices must be in the range [0, n_machines - 1]"
+    ), f"The indices must be in the range [0, n_machines - 1] (found [{affectations.min()}, {affectations.max()}])"
     ordered_index = np.arange(n_machines)
     assert np.all(
         np.sort(affectations, axis=1) == repeat(ordered_index, "m -> n m", n=n_jobs)

--- a/jssp/models/custom_agent.py
+++ b/jssp/models/custom_agent.py
@@ -26,7 +26,7 @@
 
 import numpy as np
 
-from jssp.dispatching_rules.solver import Solver, missing_tasks_to_fictive, reschedule
+from jssp.dispatching_rules.solver import Solver, reschedule
 from jssp.solution import Solution
 
 
@@ -53,7 +53,18 @@ class CustomAgent:
                 f"Unknown stochasticity strategy {self.stochasticity_strategy}"
             )
 
+        # Handle fictive tasks.
+        _, n_machines = affectations.shape
+        affectations = affectations.copy()
+        durations = durations.copy()
+        real_durations = real_durations.copy()
+
+        # Set the fictive tasks as a task on a fictive machine
+        # with a duration of 0.
+        affectations[affectations == -1] = n_machines
+        durations[durations == -1] = 0
         real_durations[real_durations == -1] = 0
+
         solver = Solver(
             durations, affectations, self.rule, ignore_unfinished_precedences=True
         )

--- a/jssp/models/custom_agent.py
+++ b/jssp/models/custom_agent.py
@@ -53,9 +53,7 @@ class CustomAgent:
                 f"Unknown stochasticity strategy {self.stochasticity_strategy}"
             )
 
-        missing_tasks_to_fictive(durations, affectations)
         real_durations[real_durations == -1] = 0
-        assert np.all(durations != -1) and np.all(affectations != -1)
         solver = Solver(
             durations, affectations, self.rule, ignore_unfinished_precedences=True
         )

--- a/jssp/models/custom_agent.py
+++ b/jssp/models/custom_agent.py
@@ -26,7 +26,7 @@
 
 import numpy as np
 
-from jssp.dispatching_rules.solver import Solver, reschedule
+from jssp.dispatching_rules.solver import Solver, missing_tasks_to_fictive, reschedule
 from jssp.solution import Solution
 
 
@@ -53,6 +53,9 @@ class CustomAgent:
                 f"Unknown stochasticity strategy {self.stochasticity_strategy}"
             )
 
+        missing_tasks_to_fictive(durations, affectations)
+        real_durations[real_durations == -1] = 0
+        assert np.all(durations != -1) and np.all(affectations != -1)
         solver = Solver(
             durations, affectations, self.rule, ignore_unfinished_precedences=True
         )

--- a/jssp/solve.py
+++ b/jssp/solve.py
@@ -58,6 +58,8 @@ if __name__ == "__main__":
         deterministic=args.duration_type == "deterministic",
     )
 
+    agent.to(args.device)
+
     print(f"Solving a {n_j}x{n_m} JSSP instance.")
 
     assert (


### PR DESCRIPTION
JSSPs with missing tasks (some jobs does not have a task on some machine) is now handled by the DR solver. Missing tasks are replaced by virtual tasks on a virtual spared machine.

Also, when solving with floating-points durations, some equalities must be tested carefully (`np.allclose` or compare with epsilons).